### PR TITLE
Port extended catalog filter UI + JupyterHub dev config (fork-only)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ tsconfig.tsbuildinfo
 *.njsproj
 *.sln
 *.sw?
+
+# Jupyter
+.ipynb_checkpoints/

--- a/docs/catalogs-extended.md
+++ b/docs/catalogs-extended.md
@@ -1,0 +1,51 @@
+# Extended Catalog Format (fork-only)
+
+This is a superset of the format described in [`catalogs.md`](catalogs.md), used only in this fork so that catalog entries can carry richer metadata for filtering. The default catalog at `public/static/catalog.json` still uses the plain format; the extended UI only activates when a loaded catalog contains any of the extended fields.
+
+## Extra dataset fields
+
+Each entry in `datasets` may also include:
+
+- `format` — e.g. `Zarr v2`, `Zarr v3`, `Icechunk`
+- `access` — e.g. `direct`, `icechunk`
+- `layout` — e.g. `simple`, `grouped`, `multiscale`
+- `grid` — e.g. `regular`, `curvilinear`, `healpix`, `triangular`, `irregular`, `gaussian_reduced`
+- `convention` — e.g. `GeoZarr`, or `null`
+- `crs` — e.g. `EPSG:4326`, `EPSG:3031`
+
+All fields are optional. Any subset can be populated per entry.
+
+## Behavior
+
+When the loaded catalog contains at least one entry with any extended field, `CatalogPanel.vue` delegates rendering to `CatalogPanelExtended.vue`, which:
+
+- shows a filter dropdown for each field that has at least one value in the dataset,
+- renders per-entry tag pills for the populated fields,
+- offers a per-entry Copy URL button that strips `::…` state suffixes and the `icechunk+` prefix.
+
+When no entry has any extended field, the existing panel is rendered unchanged.
+
+## Example
+
+```json
+{
+  "type": "gridlook_catalog",
+  "title": "Extended Catalog",
+  "datasets": [
+    {
+      "title": "ICON Daily Mean",
+      "url": "https://example.org/icon/daily_mean.zarr",
+      "format": "Zarr v3",
+      "access": "direct",
+      "layout": "grouped",
+      "grid": "healpix",
+      "convention": null,
+      "crs": "EPSG:4326"
+    }
+  ]
+}
+```
+
+## Test catalog
+
+A working extended catalog is shipped at `public/static/catalog-extended.json`. Load it via the "Open dataset" dialog (paste `static/catalog-extended.json`).

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.4.1",
   "license": "MIT",
   "scripts": {
-    "dev": "vite --port 3000",
+    "dev": "vite --port 3000 -c vite.jupyter.config.ts",
     "build": "vue-tsc -b && vite build",
     "preview": "vite preview --port 5050",
     "test": "vitest run",

--- a/public/static/catalog-extended.json
+++ b/public/static/catalog-extended.json
@@ -1,0 +1,706 @@
+{
+  "type": "gridlook_catalog",
+  "title": "Zarr Test Dataset Catalog",
+  "datasets": [
+    {
+      "title": "ARCO-OCEAN Global Ocean Reanalysis Daily",
+      "url": "https://ogs-arco-ocean.s3.eu-south-1.amazonaws.com/dataset/tres=1d/res=0p25/levels=10/",
+      "format": "Zarr v2",
+      "access": "direct",
+      "convention": null,
+      "layout": "simple",
+      "grid": "regular",
+      "crs": "EPSG:4326"
+    },
+    {
+      "title": "CMIP6 MPI-ESM1-2-HR Historical Near-Surface Air Temperature",
+      "url": "https://storage.googleapis.com/cmip6/CMIP6/CMIP/MPI-M/MPI-ESM1-2-HR/historical/r1i1p1f1/Amon/tas/gn/v20190710/",
+      "format": "Zarr v2",
+      "access": "direct",
+      "convention": null,
+      "layout": "simple",
+      "grid": "regular",
+      "crs": "EPSG:4326"
+    },
+    {
+      "title": "CMIP6 PMIP IPSL-CM6A-LR Mid-Holocene Near-Surface Air Temperature",
+      "url": "https://storage.googleapis.com/cmip6/CMIP6/PMIP/IPSL/IPSL-CM6A-LR/midHolocene/r1i1p1f3/Amon/tas/gr/v20180926/",
+      "format": "Zarr v2",
+      "access": "direct",
+      "convention": null,
+      "layout": "simple",
+      "grid": "regular",
+      "crs": "EPSG:4326"
+    },
+    {
+      "title": "CMIP6 HighResMIP HadGEM3-GC31-HM Near-Surface Air Temperature",
+      "url": "https://storage.googleapis.com/cmip6/CMIP6/HighResMIP/MOHC/HadGEM3-GC31-HM/highresSST-present/r1i1p1f1/Amon/tas/gn/v20170831/",
+      "format": "Zarr v2",
+      "access": "direct",
+      "convention": null,
+      "layout": "simple",
+      "grid": "regular",
+      "crs": "EPSG:4326"
+    },
+    {
+      "title": "Indian Ocean Physical and Biological Variables",
+      "url": "https://storage.googleapis.com/nmfs_odp_nwfsc/CB/mind_the_chl_gap/IO.zarr/::catalog=static/catalog.json::projectionCenterLat=0::projectionCenterLon=0::varname=CHL::dimIndices_time=11922::camerastate=Jc07DsJAEAPQu6RerebrmeEqKAUFRZqET6gQd2ejuHyW7O_02N7LvmzrdLlaN7iGG6xQABpbLzPzsoBSgaRJRyCZA6gUEcxten5u-_21nivUqVRM1UksPUgbdWiEHyF2geag8HHGJDQqpB_ETKCskKIBSTb__g",
+      "format": "Zarr v2",
+      "access": "direct",
+      "convention": null,
+      "layout": "simple",
+      "grid": "regular",
+      "crs": "EPSG:4326"
+    },
+    {
+      "title": "Broken - NASA Multi-scale Ultra-high Resolution (MUR) Sea Surface Temperature (SST)",
+      "url": "https://mur-sst.s3.us-west-2.amazonaws.com/zarr-v1/",
+      "format": "Zarr v2",
+      "access": "direct",
+      "convention": null,
+      "layout": "simple",
+      "grid": "regular",
+      "crs": "EPSG:4326"
+    },
+    {
+      "title": "CMIP6 NOAA GFDL-ESM4 Historical Sea Surface Temperature",
+      "url": "https://storage.googleapis.com/cmip6/CMIP6/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r2i1p1f1/Omon/tos/gn/v20180701/",
+      "format": "Zarr v2",
+      "access": "direct",
+      "convention": null,
+      "layout": "grouped",
+      "grid": "curvilinear",
+      "crs": "EPSG:4326"
+    },
+    {
+      "title": "CMIP6 AWI-CM-1-1-MR Historical Daily Sea Surface Temperature",
+      "url": "https://cmip6-pds.s3.amazonaws.com/CMIP6/CMIP/AWI/AWI-CM-1-1-MR/historical/r1i1p1f1/Oday/tos/gn/v20181218/",
+      "format": "Zarr v2",
+      "access": "direct",
+      "convention": null,
+      "layout": "grouped",
+      "grid": "irregular",
+      "crs": "EPSG:4326"
+    },
+    {
+      "title": "ERA5 Hurricane Florence Atmospheric Reanalysis Layers",
+      "url": "https://atlantis-vis-o.s3-ext.jc.rl.ac.uk/hurricanes/era5/florence::catalog=static/catalog.json::projectionCenterLat=0::projectionCenterLon=0::varname=surface_pressure::dimIndices_time=0::camerastate=JYw5DsJAFMXuknoY_eX9jaugFBQUaRKWUCHuzqCUtmR_pvv2WvZlW6fzBV3BJS4waFahnVi7GnGwSIKlDC16ZCKZko20Muc2Pd7X_fZcjw31UbAQTFBlYY06RQHiGlnM5PV3rCjBIJcAzGO4NKZC-XgHJWL-_gA",
+      "format": "Zarr v3",
+      "access": "direct",
+      "convention": null,
+      "layout": "simple",
+      "grid": "regular",
+      "crs": "EPSG:4326"
+    },
+    {
+      "title": "Fish-PACE Global Chlorophyll Vertical Structure",
+      "url": "https://storage.googleapis.com/nmfs_odp_nwfsc/CB/fish-pace-datasets/chla-z/zarr",
+      "format": "Zarr v3",
+      "access": "direct",
+      "convention": null,
+      "layout": "simple",
+      "grid": "regular",
+      "crs": "EPSG:4326"
+    },
+    {
+      "title": "NOAA Global Forecast System (GFS) Global Weather Forecast",
+      "url": "icechunk+https://dynamical-noaa-gfs.s3.us-west-2.amazonaws.com/noaa-gfs-forecast/v0.2.7.icechunk/",
+      "format": "Zarr v3",
+      "access": "icechunk",
+      "convention": null,
+      "layout": "simple",
+      "grid": "regular",
+      "crs": "EPSG:4326"
+    },
+    {
+      "title": "Deutscher Wetterdienst (DWD) ICON-EU Numerical Weather Forecast",
+      "url": "icechunk+https://dynamical-dwd-icon-eu.s3.us-west-2.amazonaws.com/dwd-icon-eu-forecast-5-day/v0.2.0.icechunk/::catalog=static/catalog.json::projectionCenterLat=0::projectionCenterLon=0::varname=cloud_cover_high::dimIndices_init_time=0::dimIndices_lead_time=0::camerastate=Jc05DsJAEETRuzgejXqpru7hKoiAgMCJzWIixN2xhSp7Qf3PdF9f8zavy3Q6j65eyaIA6QU26-WJ5PASM2Wg6W5DMlQzU1OGXdr0eF-323P530jXosaAByllQm_SLSyNEAHNmbpTEgjUsCMCs52CrnLMPdxRl-8P",
+      "format": "Zarr v3",
+      "access": "icechunk",
+      "convention": null,
+      "layout": "simple",
+      "grid": "regular",
+      "crs": "EPSG:4326"
+    },
+    {
+      "title": "ECMWF Artificial Intelligence Forecasting System (AIFS) Single Forecast",
+      "url": "icechunk+https://dynamical-ecmwf-aifs-single.s3.us-west-2.amazonaws.com/ecmwf-aifs-single-forecast/v0.1.0.icechunk/",
+      "format": "Zarr v3",
+      "access": "icechunk",
+      "convention": null,
+      "layout": "simple",
+      "grid": "regular",
+      "crs": "EPSG:4326"
+    },
+    {
+      "title": "WCRP Hackathon ICON Global Weather Simulation Atmosphere Dataset",
+      "url": "https://s3.eu-dkrz-1.dkrz.cloud/wrcp-hackathon/data/ICON/d3hp003.zarr/P1D_mean_z7_atm",
+      "format": "Zarr v3",
+      "access": "direct",
+      "convention": null,
+      "layout": "grouped",
+      "grid": "healpix",
+      "crs": "EPSG:4326"
+    },
+    {
+      "title": "UK Met Office Global Wave Forecast",
+      "url": "icechunk+https://data.source.coop/bkr/metoffice/metoffice_global_wave.icechunk",
+      "format": "Zarr v3",
+      "access": "icechunk",
+      "convention": null,
+      "layout": "simple",
+      "grid": "regular",
+      "crs": "EPSG:4326"
+    },
+    {
+      "title": "UK Met Office Global Deterministic Atmosphere Forecast (6-hourly)",
+      "url": "icechunk+https://data.source.coop/bkr/metoffice/metoffice_global_deterministic_10km_6hourly_24hr.icechunk",
+      "format": "Zarr v3",
+      "access": "icechunk",
+      "convention": null,
+      "layout": "simple",
+      "grid": "regular",
+      "crs": "EPSG:4326"
+    },
+    {
+      "title": "NASA GEOS Atmospheric Reanalysis (15-minute)",
+      "url": "icechunk+https://data.source.coop/bkr/geos/geos_15min.icechunk",
+      "format": "Zarr v3",
+      "access": "icechunk",
+      "convention": null,
+      "layout": "simple",
+      "grid": "regular",
+      "crs": "EPSG:4326"
+    },
+    {
+      "title": "UK Met Office Global Deterministic Atmosphere Forecast (11-hour)",
+      "url": "icechunk+https://data.source.coop/bkr/metoffice/metoffice_global_deterministic_10km_11hour.icechunk",
+      "format": "Zarr v3",
+      "access": "icechunk",
+      "convention": null,
+      "layout": "simple",
+      "grid": "regular",
+      "crs": "EPSG:4326"
+    },
+    {
+      "title": "UK Met Office Global Deterministic Atmosphere Forecast",
+      "url": "icechunk+https://data.source.coop/bkr/metoffice/metoffice_global_deterministic_10km.icechunk",
+      "format": "Zarr v3",
+      "access": "icechunk",
+      "convention": null,
+      "layout": "simple",
+      "grid": "regular",
+      "crs": "EPSG:4326"
+    },
+    {
+      "title": "ERA5 Surface Reanalysis Reanalysis Multi-Variable, Spatial group",
+      "url": "icechunk+https://earthmover-icechunk-era5.s3.us-east-1.amazonaws.com/era5_surface_aws/spatial",
+      "format": "Zarr v3",
+      "access": "icechunk",
+      "convention": null,
+      "layout": "grouped",
+      "grid": "regular",
+      "crs": "EPSG:4326"
+    },
+    {
+      "title": "Earthmover ERA5 Surface Reanalysis Multi-Variable",
+      "url": "icechunk+https://earthmover-icechunk-era5.s3.us-east-1.amazonaws.com/era5_surface_aws",
+      "format": "Zarr v3",
+      "access": "icechunk",
+      "convention": null,
+      "layout": "grouped",
+      "grid": "regular",
+      "crs": "EPSG:4326"
+    },
+    {
+      "title": "NOAA HRRR High-Resolution Rapid Refresh Analysis",
+      "url": "icechunk+https://dynamical-noaa-hrrr.s3.us-west-2.amazonaws.com/noaa-hrrr-analysis/v0.2.0.icechunk/",
+      "format": "Zarr v3",
+      "access": "icechunk",
+      "convention": null,
+      "layout": "simple",
+      "grid": "lambert",
+      "crs": "EPSG:4326"
+    },
+    {
+      "title": "NOAA MRMS CONUS Hourly Radar-Based Precipitation Analysis",
+      "url": "icechunk+https://dynamical-noaa-mrms.s3.amazonaws.com/noaa-mrms-conus-analysis-hourly/v0.3.0.icechunk/",
+      "format": "Zarr v3",
+      "access": "icechunk",
+      "convention": null,
+      "layout": "simple",
+      "grid": "regular",
+      "crs": "EPSG:4326"
+    },
+    {
+      "title": "ECMWF AIFS Ensemble Forecast",
+      "url": "icechunk+https://dynamical-ecmwf-aifs-ens.s3.us-west-2.amazonaws.com/ecmwf-aifs-ens-forecast/v0.1.0.icechunk/",
+      "format": "Zarr v3",
+      "access": "icechunk",
+      "convention": null,
+      "layout": "simple",
+      "grid": "regular",
+      "crs": "EPSG:4326"
+    },
+    {
+      "title": "ECMWF IFS Ensemble 15-day Weather Forecast (0.25°)",
+      "url": "icechunk+https://dynamical-ecmwf-ifs-ens.s3.us-west-2.amazonaws.com/ecmwf-ifs-ens-forecast-15-day-0-25-degree/v0.1.0.icechunk/",
+      "format": "Zarr v3",
+      "access": "icechunk",
+      "convention": null,
+      "layout": "simple",
+      "grid": "regular",
+      "crs": "EPSG:4326"
+    },
+    {
+      "title": "Slow - NOAA GEFS Global Ensemble Forecast Analysis",
+      "url": "icechunk+https://dynamical-noaa-gefs.s3.us-west-2.amazonaws.com/noaa-gefs-analysis/v0.1.2.icechunk/",
+      "format": "Zarr v3",
+      "access": "icechunk",
+      "convention": null,
+      "layout": "simple",
+      "grid": "regular",
+      "crs": "EPSG:4326"
+    },
+    {
+      "title": "Broken - ISMIP6 Antarctic Ice Sheet Model Intercomparison",
+      "url": "icechunk+https://data.source.coop/englacial/ismip6/icechunk-ais",
+      "format": "Zarr v3",
+      "access": "icechunk",
+      "convention": null,
+      "layout": "grouped",
+      "grid": "polar_stereographic",
+      "crs": "EPSG:3031"
+    },
+    {
+      "title": "Broken - ISMIP6 Antarctic Ice Sheet — AWI_PISM1 Exp 05",
+      "url": "icechunk+https://data.source.coop/englacial/ismip6/icechunk-ais/combined/AWI_PISM1/exp05",
+      "format": "Zarr v3",
+      "access": "icechunk",
+      "convention": null,
+      "layout": "grouped",
+      "grid": "polar_stereographic",
+      "crs": "EPSG:3031"
+    },
+    {
+      "title": "NOAA GEFS 35-day Ensemble Forecast",
+      "url": "icechunk+https://dynamical-noaa-gefs.s3.us-west-2.amazonaws.com/noaa-gefs-forecast-35-day/v0.2.0.icechunk/",
+      "format": "Zarr v3",
+      "access": "icechunk",
+      "convention": null,
+      "layout": "simple",
+      "grid": "regular",
+      "crs": "EPSG:4326"
+    },
+    {
+      "title": "NOAA GEFS 35-day Ensemble Forecast",
+      "url": "https://data.dynamical.org/noaa/gefs/forecast-35-day/latest.zarr",
+      "format": "Zarr v3",
+      "access": "direct",
+      "convention": null,
+      "layout": "simple",
+      "grid": "regular",
+      "crs": "EPSG:4326"
+    },
+    {
+      "title": "Broken - AOML Oceanographic Demo Dataset (2012)",
+      "url": "icechunk+https://data.source.coop/bkr/aoml/aoml_2012.icechunk",
+      "format": "Zarr v3",
+      "access": "icechunk",
+      "convention": null,
+      "layout": "simple",
+      "grid": "regular",
+      "crs": "EPSG:4326"
+    },
+    {
+      "title": "ERA5 Single-Level Atmospheric Reanalysis Multi-Variable",
+      "url": "https://storage.googleapis.com/gcp-public-data-arco-era5/co/single-level-reanalysis.zarr-v2",
+      "format": "Zarr v2",
+      "access": "direct",
+      "convention": null,
+      "layout": "simple",
+      "grid": "regular",
+      "crs": "EPSG:4326"
+    },
+    {
+      "title": "NEMO Ocean Model Currents",
+      "url": "https://atlantis-vis-o.s3-ext.jc.rl.ac.uk/nemotest101/currents/uo.zarr",
+      "format": "Zarr v2",
+      "access": "direct",
+      "convention": null,
+      "layout": "simple",
+      "grid": "regular",
+      "crs": "EPSG:4326"
+    },
+    {
+      "title": "Nucleus for European Modelling of the Ocean (NEMO) Daily Surface Salinity",
+      "url": "https://atlantis-vis-o.s3-ext.jc.rl.ac.uk/nemotest101/T1d/sos_abs.zarr",
+      "format": "Zarr v2",
+      "access": "direct",
+      "convention": null,
+      "layout": "simple",
+      "grid": "regular",
+      "crs": "EPSG:4326"
+    },
+    {
+      "title": "National Oceanography Centre (NOC) Near-Present-Day (NPD) EORCA1 ERA5 Absolute Salinity",
+      "url": "https://atlantis-vis-o.s3-ext.jc.rl.ac.uk/noc-npd-era5-demo/npd-eorca1-era5v1/gn/T1y/so_abs",
+      "format": "Zarr v3",
+      "access": "direct",
+      "convention": "GeoZarr",
+      "layout": "multiscale",
+      "grid": "regular",
+      "crs": "EPSG:4326"
+    },
+    {
+      "title": "National Oceanography Centre (NOC) Near-Present-Day (NPD) EORCA025 ERA5 Conservative Temperature",
+      "url": "https://atlantis-vis-o.s3-ext.jc.rl.ac.uk/noc-npd-era5-demo/npd-eorca025-era5v1/gn/T1y_4d/thetao_con",
+      "format": "Zarr v3",
+      "access": "direct",
+      "convention": "GeoZarr",
+      "layout": "multiscale",
+      "grid": "regular",
+      "crs": "EPSG:4326"
+    },
+    {
+      "title": "National Oceanography Centre (NOC) Near-Present-Day (NPD) EORCA1 ERA5 Ocean Currents",
+      "url": "https://atlantis-vis-o.s3-ext.jc.rl.ac.uk/noc-npd-era5-demo/npd-eorca1-era5v1/gn/U1y/uo2",
+      "format": "Zarr v3",
+      "access": "direct",
+      "convention": "GeoZarr",
+      "layout": "multiscale",
+      "grid": "regular",
+      "crs": "EPSG:4326"
+    },
+    {
+      "title": "Nucleus for European Modelling of the Ocean (NEMO) Surface Salinity",
+      "url": "https://atlantis-vis-o.s3-ext.jc.rl.ac.uk/nemotest101/pyramid2/T1d/sos_abs.zarr",
+      "format": "Zarr v2",
+      "access": "direct",
+      "convention": "GeoZarr",
+      "layout": "multiscale",
+      "grid": "regular",
+      "crs": "EPSG:4326"
+    },
+    {
+      "title": "National Oceanography Centre (NOC) Near-Present-Day (NPD) EORCA1 ERA5 Conservative SST",
+      "url": "https://atlantis-vis-o.s3-ext.jc.rl.ac.uk/noc-npd-era5-demo/npd-eorca1-era5v1/gn/T1y/tos_con",
+      "format": "Zarr v3",
+      "access": "direct",
+      "convention": "GeoZarr",
+      "layout": "multiscale",
+      "grid": "regular",
+      "crs": "EPSG:4326"
+    },
+    {
+      "title": "CarbonPlan Demo Dataset Monthly Temperature & Precipitation",
+      "url": "https://carbonplan-maps.s3.us-west-2.amazonaws.com/v2/demo/4d/tavg-prec-month",
+      "format": "Zarr v2",
+      "access": "direct",
+      "convention": "GeoZarr",
+      "layout": "multiscale",
+      "grid": "regular",
+      "crs": "EPSG:4326"
+    },
+    {
+      "title": "CarbonPlan Antarctic ERA5 Reanalysis",
+      "url": "https://carbonplan-share.s3.us-west-2.amazonaws.com/zarr-layer-examples/antarctic_era5.zarr",
+      "format": "Zarr v2",
+      "access": "direct",
+      "convention": null,
+      "layout": "simple",
+      "grid": "polar_stereographic",
+      "crs": "EPSG:3031"
+    },
+    {
+      "title": "Slow - CarbonPlan Polar Projection Example Dataset",
+      "url": "https://carbonplan-share.s3.us-west-2.amazonaws.com/zarr-layer-examples/polar-subset.zarr",
+      "format": "Zarr v2",
+      "access": "direct",
+      "convention": null,
+      "layout": "simple",
+      "grid": "polar_stereographic",
+      "crs": "EPSG:3031"
+    },
+    {
+      "title": "CarbonPlan Multi-Level Hybrid Virtual Icechunk",
+      "url": "icechunk+https://carbonplan-share.s3.us-west-2.amazonaws.com/zarr-layer-examples/pipeline/multi_level_virtual_hybrid_icechunk.icechunk",
+      "format": "Zarr v3",
+      "access": "icechunk",
+      "convention": "GeoZarr",
+      "layout": "multiscale",
+      "grid": "regular",
+      "crs": "EPSG:4326"
+    },
+    {
+      "title": "Broken - Sentinel-2 L2A Surface Reflectance Tile T37TBG",
+      "url": "https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/tests-output/sentinel-2-l2a/S2C_MSIL2A_20251218T083401_N0511_R021_T37TBG_20251218T112007.zarr/measurements/reflectance",
+      "format": "Zarr v3",
+      "access": "direct",
+      "convention": null,
+      "layout": "grouped",
+      "grid": "utm",
+      "crs": "EPSG:32637"
+    },
+    {
+      "title": "SILAM Global Dust Model Forecasts - Aerosol",
+      "url": "icechunk+https://data.source.coop/bkr/silam-dust/silam_aerosol.icechunk",
+      "format": "Zarr v3",
+      "access": "icechunk",
+      "convention": null,
+      "layout": "simple",
+      "grid": "regular",
+      "crs": "EPSG:4326"
+    },
+    {
+      "title": "SILAM Global Dust Model Forecasts - Dust",
+      "url": "https://data.source.coop/bkr/silam-dust/silam_global_dust_v3.zarr",
+      "format": "Zarr v3",
+      "access": "direct",
+      "convention": null,
+      "layout": "simple",
+      "grid": "regular",
+      "crs": "EPSG:4326"
+    },
+    {
+      "title": "SILAM Global Dust Model Forecasts - Dust",
+      "url": "https://data.source.coop/bkr/silam-dust/data.zarr",
+      "format": "Zarr v2",
+      "access": "direct",
+      "convention": null,
+      "layout": "simple",
+      "grid": "regular",
+      "crs": "EPSG:4326"
+    },
+    {
+      "title": "CAMS Aerosol Analysis from the Copernicus CAMS operational archive",
+      "url": "icechunk+https://data.source.coop/bkr/cams/cams.icechunk::dimIndices_time=4593::catalog=static%2Fcatalog.json",
+      "format": "Zarr v3",
+      "access": "icechunk",
+      "convention": null,
+      "layout": "simple",
+      "grid": "regular",
+      "crs": "EPSG:4326"
+    },
+    {
+      "title": "CAMS Aerosol Forecast from the Copernicus CAMS operational archive",
+      "url": "icechunk+https://data.source.coop/bkr/cams/cams_analysis_and_forecast.icechunk",
+      "format": "Zarr v3",
+      "access": "icechunk",
+      "convention": null,
+      "layout": "simple",
+      "grid": "regular",
+      "crs": "EPSG:4326"
+    },
+    {
+      "title": "NASA Risk Analysis and Solutions Innovators (RASI)",
+      "url": "https://nasa-waterinsight.s3.us-west-2.amazonaws.com/virtual-zarr-store/icechunk/RASI/HISTORICAL/::catalog=static/catalog.json::projectionCenterLat=0::projectionCenterLon=0::varname=AvgSurfT_Percentiles::dimIndices_time=0::dimIndices_percentile=0::camerastate=JYw5DsJQEMXukvrna97sw1VQCgqKNAlLqBB3JxDJheXC7-G2PudtXpfhdB6la7CVhDqrGyPaCOkoSWQm77Kn7OooZGhADJjacH9dtutjOTbUNZmNqMoEf9pInfYnAe5JUcnlvwgwhEXBpaLG1qinu6V4lFekhUyfLw::maskmode=sea::maskusetexture=false::projection=nearside_perspective",
+      "format": "Zarr v3",
+      "access": "icechunk",
+      "convention": null,
+      "layout": "simple",
+      "grid": "regular",
+      "crs": "EPSG:4326"
+    },
+    {
+      "title": "HadGEM3-GC5E-HH Historical Monthly Atmosphere",
+      "url": "https://eerie.cloud.dkrz.de/datasets/HadGEM3-GC5E-HH.historical.v20250409.gr1.Amon/stac",
+      "format": "Zarr v2",
+      "access": "direct",
+      "convention": null,
+      "layout": "simple",
+      "grid": "regular",
+      "crs": "EPSG:4326"
+    },
+    {
+      "title": "CORDEX-CMIP6 EUR-12 CNRM-ESM2-1 Historical Daily",
+      "url": "https://eerie.cloud.dkrz.de/datasets/cordex-cmip6.DD.EUR-12.CLMcom-BTU.CNRM-ESM2-1.historical.r1i1p1f2.ICON-CLM-202407-1-1.v1-r1.day/stac",
+      "format": "Zarr v2",
+      "access": "direct",
+      "convention": null,
+      "layout": "simple",
+      "grid": "regular_rotated",
+      "crs": "EPSG:4326"
+    },
+    {
+      "title": "CORDEX-CMIP6 EUR-12 MPI-ESM1-2-HR Historical Daily",
+      "url": "https://eerie.cloud.dkrz.de/datasets/cordex-cmip6.DD.EUR-12.CLMcom-DWD.MPI-ESM1-2-HR.historical.r1i1p1f1.ICON-CLM-202407-1-1.v1-r1.day/stac",
+      "format": "Zarr v2",
+      "access": "direct",
+      "convention": null,
+      "layout": "simple",
+      "grid": "regular_rotated",
+      "crs": "EPSG:4326"
+    },
+    {
+      "title": "CORDEX-CMIP6 EUR-12 EC-Earth3-Veg SSP1-2.6 Daily",
+      "url": "https://eerie.cloud.dkrz.de/datasets/cordex-cmip6.DD.EUR-12.CLMcom-GERICS.EC-Earth3-Veg.ssp126.r1i1p1f1.ICON-CLM-202407-1-1.v1-r1.day/stac",
+      "format": "Zarr v2",
+      "access": "direct",
+      "convention": null,
+      "layout": "simple",
+      "grid": "regular_rotated",
+      "crs": "EPSG:4326"
+    },
+    {
+      "title": "COSMO-REA Hourly Point Atmosphere",
+      "url": "https://eerie.cloud.dkrz.de/datasets/cosmo-rea-1hrPt_atmos/stac",
+      "format": "Zarr v2",
+      "access": "direct",
+      "convention": null,
+      "layout": "simple",
+      "grid": "regular_rotated",
+      "crs": "EPSG:4326"
+    },
+    {
+      "title": "ERA5-DKRZ Surface Analysis Hourly",
+      "url": "https://eerie.cloud.dkrz.de/datasets/era5-dkrz.surface_analysis_hourly/stac",
+      "format": "Zarr v2",
+      "access": "direct",
+      "convention": null,
+      "layout": "simple",
+      "grid": "irregular",
+      "crs": "EPSG:4326"
+    },
+    {
+      "title": "ERA5-Land-DKRZ Surface Analysis Hourly",
+      "url": "https://eerie.cloud.dkrz.de/datasets/era5-land-dkrz.surface_analysis_hourly/stac",
+      "format": "Zarr v2",
+      "access": "direct",
+      "convention": null,
+      "layout": "simple",
+      "grid": "irregular",
+      "crs": "EPSG:4326"
+    },
+    {
+      "title": "Mild Error - ICON-EPOC Control 1990 Atmosphere Daily Mean",
+      "url": "https://eerie.cloud.dkrz.de/datasets/icon-epoc.control-1990.v20250325.atmos.native.2d_daily_mean/stac",
+      "format": "Zarr v2",
+      "access": "direct",
+      "convention": null,
+      "layout": "simple",
+      "grid": "triangular",
+      "crs": "EPSG:4326"
+    },
+    {
+      "title": "Mild Error - ICON-EPOC Control 1990 Ocean Daily Mean",
+      "url": "https://eerie.cloud.dkrz.de/datasets/icon-epoc.control-1990.v20250325.ocean.native.2d_daily_mean/stac::varname=Wind_Speed_10m",
+      "format": "Zarr v2",
+      "access": "direct",
+      "convention": null,
+      "layout": "simple",
+      "grid": "triangular",
+      "crs": "EPSG:4326"
+    },
+    {
+      "title": "ICON-ESM-ER High-Resolution Future SSP2-4.5 Atmosphere Hourly",
+      "url": "https://eerie.cloud.dkrz.de/datasets/icon-esm-er.highres-future-ssp245.v20240618.atmos.native.2d_1h_inst/stac",
+      "format": "Zarr v2",
+      "access": "direct",
+      "convention": null,
+      "layout": "simple",
+      "grid": "triangular",
+      "crs": "EPSG:4326"
+    },
+    {
+      "title": "IFS-AMIP TCo1279 Historical Atmosphere Daily",
+      "url": "https://eerie.cloud.dkrz.de/datasets/ifs-amip-tco1279.hist.v20240901.atmos.gr025.2D_24h/stac",
+      "format": "Zarr v2",
+      "access": "direct",
+      "convention": null,
+      "layout": "simple",
+      "grid": "irregular",
+      "crs": "EPSG:4326"
+    },
+    {
+      "title": "IFS-AMIP TCo2559 Historical Atmosphere Hourly",
+      "url": "https://eerie.cloud.dkrz.de/datasets/ifs-amip-tco2559.hist.v20240901.atmos.gr025.2D_1h/stac",
+      "format": "Zarr v2",
+      "access": "direct",
+      "convention": null,
+      "layout": "simple",
+      "grid": "irregular",
+      "crs": "EPSG:4326"
+    },
+    {
+      "title": "Mild Error - IFS-FESOM2-SR Historical 1950 Ocean Daily Mean",
+      "url": "https://eerie.cloud.dkrz.de/datasets/ifs-fesom2-sr.hist-1950.v20240304.ocean.gr025.2D_daily_avg_1950-2014/stac",
+      "format": "Zarr v2",
+      "access": "direct",
+      "convention": null,
+      "layout": "simple",
+      "grid": "regular",
+      "crs": "EPSG:4326"
+    },
+    {
+      "title": "IFS-NEMO-ER High-Resolution Future SSP2-4.5 Atmosphere Monthly",
+      "url": "https://eerie.cloud.dkrz.de/datasets/ifs-nemo-er.highres-future-ssp245.v20250516.atmos.gr025.Amon/stac",
+      "format": "Zarr v2",
+      "access": "direct",
+      "convention": null,
+      "layout": "simple",
+      "grid": "regular",
+      "crs": "EPSG:4326"
+    },
+    {
+      "title": "NextGEMS IFS 2.8 / FESOM 5 Production Ocean Daily HEALPix",
+      "url": "https://eerie.cloud.dkrz.de/datasets/nextgems.IFS_2.8-FESOM_5-production.2D_daily_healpix128_ocean/stac",
+      "format": "Zarr v2",
+      "access": "direct",
+      "convention": null,
+      "layout": "simple",
+      "grid": "healpix",
+      "crs": "EPSG:4326"
+    },
+    {
+      "title": "NextGEMS IFS 2.8 / FESOM 5 Production Deep-Off Ocean Daily HEALPix",
+      "url": "https://eerie.cloud.dkrz.de/datasets/nextgems.IFS_2.8-FESOM_5-production-deep-off.2D_daily_healpix128_ocean/stac",
+      "format": "Zarr v2",
+      "access": "direct",
+      "convention": null,
+      "layout": "simple",
+      "grid": "healpix",
+      "crs": "EPSG:4326"
+    },
+    {
+      "title": "ORCESTRA 1250 m 2D HEALPix",
+      "url": "https://eerie.cloud.dkrz.de/datasets/orcestra_1250m_2d_hpz12/stac",
+      "format": "Zarr v2",
+      "access": "direct",
+      "convention": null,
+      "layout": "simple",
+      "grid": "healpix",
+      "crs": "EPSG:4326"
+    },
+    {
+      "title": "ORCESTRA 1250 m 3D HEALPix",
+      "url": "https://eerie.cloud.dkrz.de/datasets/orcestra_1250m_3d_hpz12/stac",
+      "format": "Zarr v2",
+      "access": "direct",
+      "convention": null,
+      "layout": "simple",
+      "grid": "healpix",
+      "crs": "EPSG:4326"
+    },
+    {
+      "title": "Alaska HRRR",
+      "url": "https://data.source.coop/bkr/dmi/alaska_hrrr.icechunk::catalog=static/catalog.json::projectionCenterLat=0::projectionCenterLon=0::varname=10_metre_u_wind_component_at_10.0m::dimIndices_time=0::dimIndices_step=0::camerastate=Jcw5DsJAEETRuzgej7q7euUqiICAwInNYiLE3RnkoJL60vtM9-217Mu2TqfznB0I8gwhUStom6UzFRjlmZXkkY3RzdxLTMnK_NKmx_u6357rwVAXIQqgSj3VTIdDnYMhKVzKgI30Py2rRFyRNFbcqIdFOMyZODQG__0B::dimIndices_level=0::projection=nearside_perspective",
+      "format": "Zarr v3",
+      "access": "icechunk",
+      "convention": null,
+      "layout": "simple",
+      "grid": "polar_stereographic",
+      "crs": "EPSG:3413"
+    },
+    {
+      "title": "Normalized Difference Vegetation Index (NDVI) test",
+      "url": "https://data.source.coop/eeholmes/chlaz/icechunk",
+      "format": "Zarr v3",
+      "access": "icechunk",
+      "convention": null,
+      "layout": "simple",
+      "grid": "regular",
+      "crs": "EPSG:4326"
+    }
+  ]
+}

--- a/src/ui/overlays/controls/CatalogPanel.vue
+++ b/src/ui/overlays/controls/CatalogPanel.vue
@@ -1,6 +1,8 @@
 <script lang="ts" setup>
 import { computed, ref } from "vue";
 
+import CatalogPanelExtended from "./CatalogPanelExtended.vue";
+
 import type { TCatalogEntry } from "@/utils/catalog.ts";
 
 const props = defineProps<{
@@ -11,6 +13,12 @@ const props = defineProps<{
 const emit = defineEmits<{
   select: [entry: TCatalogEntry];
 }>();
+
+const hasExtendedFields = computed(() =>
+  props.datasets.some(
+    (d) => d.format || d.access || d.layout || d.grid || d.convention || d.crs
+  )
+);
 
 const searchQuery = ref("");
 
@@ -54,7 +62,13 @@ function select(entry: TCatalogEntry) {
 </script>
 
 <template>
-  <nav class="catalog-panel mt-4 pt-2">
+  <CatalogPanelExtended
+    v-if="hasExtendedFields"
+    :title="title"
+    :datasets="datasets"
+    @select="(entry) => emit('select', entry)"
+  />
+  <nav v-else class="catalog-panel mt-4 pt-2">
     <h2 class="catalog-title">
       {{ title ?? "Dataset Catalog" }}
     </h2>

--- a/src/ui/overlays/controls/CatalogPanelExtended.vue
+++ b/src/ui/overlays/controls/CatalogPanelExtended.vue
@@ -1,0 +1,429 @@
+<script lang="ts" setup>
+import { computed, ref } from "vue";
+
+import type { TCatalogEntry } from "@/utils/catalog.ts";
+
+const props = defineProps<{
+  title?: string;
+  datasets: TCatalogEntry[];
+}>();
+
+const emit = defineEmits<{
+  select: [entry: TCatalogEntry];
+}>();
+
+const searchQuery = ref("");
+const copiedUrl = ref<string | null>(null);
+const copyFailedUrl = ref<string | null>(null);
+const COPY_FEEDBACK_DURATION_MS = 1500;
+
+const filterFormat = ref("all");
+const filterAccess = ref("all");
+const filterLayout = ref("all");
+const filterGrid = ref("all");
+const filterConvention = ref("all");
+const filterCrs = ref("all");
+
+const uniqueFormats = computed(() =>
+  Array.from(
+    new Set(props.datasets.map((d) => d.format).filter((v): v is string => !!v))
+  ).sort()
+);
+
+const uniqueAccessTypes = computed(() =>
+  Array.from(
+    new Set(props.datasets.map((d) => d.access).filter((v): v is string => !!v))
+  ).sort()
+);
+
+const uniqueLayouts = computed(() =>
+  Array.from(
+    new Set(props.datasets.map((d) => d.layout).filter((v): v is string => !!v))
+  ).sort()
+);
+
+const uniqueGridTypes = computed(() =>
+  Array.from(
+    new Set(props.datasets.map((d) => d.grid).filter((v): v is string => !!v))
+  ).sort()
+);
+
+const uniqueConventions = computed(() =>
+  Array.from(
+    new Set(
+      props.datasets.map((d) => d.convention).filter((v): v is string => !!v)
+    )
+  ).sort()
+);
+
+const uniqueCrsTypes = computed(() =>
+  Array.from(
+    new Set(props.datasets.map((d) => d.crs).filter((v): v is string => !!v))
+  ).sort()
+);
+
+const filteredDatasets = computed(() => {
+  const q = searchQuery.value.trim().toLowerCase();
+
+  return props.datasets.filter((entry) => {
+    if (q) {
+      const haystack = [
+        entry.title ?? "",
+        entry.url,
+        entry.format ?? "",
+        entry.access ?? "",
+        entry.layout ?? "",
+        entry.grid ?? "",
+        entry.convention ?? "",
+        entry.crs ?? "",
+        entry.description ?? "",
+      ]
+        .join(" ")
+        .toLowerCase();
+      if (!haystack.includes(q)) {
+        return false;
+      }
+    }
+
+    if (filterFormat.value !== "all" && entry.format !== filterFormat.value) {
+      return false;
+    }
+    if (filterAccess.value !== "all" && entry.access !== filterAccess.value) {
+      return false;
+    }
+    if (filterLayout.value !== "all" && entry.layout !== filterLayout.value) {
+      return false;
+    }
+    if (filterGrid.value !== "all" && entry.grid !== filterGrid.value) {
+      return false;
+    }
+    if (
+      filterConvention.value !== "all" &&
+      entry.convention !== filterConvention.value
+    ) {
+      return false;
+    }
+    if (filterCrs.value !== "all" && entry.crs !== filterCrs.value) {
+      return false;
+    }
+
+    return true;
+  });
+});
+
+function displayTitle(entry: TCatalogEntry): string {
+  return entry.title ?? entry.url;
+}
+
+function select(entry: TCatalogEntry) {
+  emit("select", entry);
+}
+
+function cleanCatalogUrl(url: string): string {
+  const base = url.split("::")[0];
+  return base.replace(/^icechunk\+/, "");
+}
+
+async function copyUrl(url: string) {
+  try {
+    await navigator.clipboard.writeText(cleanCatalogUrl(url));
+    copyFailedUrl.value = null;
+    copiedUrl.value = url;
+    setTimeout(() => {
+      if (copiedUrl.value === url) {
+        copiedUrl.value = null;
+      }
+    }, COPY_FEEDBACK_DURATION_MS);
+  } catch {
+    copiedUrl.value = null;
+    copyFailedUrl.value = url;
+    setTimeout(() => {
+      if (copyFailedUrl.value === url) {
+        copyFailedUrl.value = null;
+      }
+    }, COPY_FEEDBACK_DURATION_MS);
+  }
+}
+</script>
+
+<template>
+  <nav class="catalog-panel mt-4 pt-2">
+    <h2 class="catalog-title">
+      {{ title ?? "Dataset Catalog" }}
+    </h2>
+    <div class="is-flex-direction-column my-3 w-100">
+      <div class="control has-icons-left mb-2">
+        <input
+          v-model="searchQuery"
+          class="input is-small"
+          type="text"
+          placeholder="Search datasets…"
+        />
+        <span class="icon is-left is-small">
+          <i class="fa-solid fa-magnifying-glass"></i>
+        </span>
+      </div>
+      <div
+        class="is-flex is-align-items-center is-justify-content-space-between w-100 catalog-filters"
+      >
+        <span class="is-size-7 has-text-grey">
+          {{ filteredDatasets.length }} /
+          {{ datasets.length }}
+          dataset{{ datasets.length !== 1 ? "s" : "" }}
+        </span>
+        <div class="field is-grouped is-align-items-center mb-0">
+          <div v-if="uniqueFormats.length > 0" class="control">
+            <div class="select is-small">
+              <select v-model="filterFormat" title="Filter by format">
+                <option value="all">Format: All</option>
+                <option v-for="v in uniqueFormats" :key="v" :value="v">
+                  {{ v }}
+                </option>
+              </select>
+            </div>
+          </div>
+          <div v-if="uniqueAccessTypes.length > 0" class="control">
+            <div class="select is-small">
+              <select v-model="filterAccess" title="Filter by access">
+                <option value="all">Access: All</option>
+                <option v-for="v in uniqueAccessTypes" :key="v" :value="v">
+                  {{ v }}
+                </option>
+              </select>
+            </div>
+          </div>
+          <div v-if="uniqueLayouts.length > 0" class="control">
+            <div class="select is-small">
+              <select v-model="filterLayout" title="Filter by layout">
+                <option value="all">Layout: All</option>
+                <option v-for="v in uniqueLayouts" :key="v" :value="v">
+                  {{ v }}
+                </option>
+              </select>
+            </div>
+          </div>
+          <div v-if="uniqueGridTypes.length > 0" class="control">
+            <div class="select is-small">
+              <select v-model="filterGrid" title="Filter by grid type">
+                <option value="all">Grid: All</option>
+                <option v-for="v in uniqueGridTypes" :key="v" :value="v">
+                  {{ v }}
+                </option>
+              </select>
+            </div>
+          </div>
+          <div v-if="uniqueConventions.length > 0" class="control">
+            <div class="select is-small">
+              <select v-model="filterConvention" title="Filter by convention">
+                <option value="all">Convention: All</option>
+                <option v-for="v in uniqueConventions" :key="v" :value="v">
+                  {{ v }}
+                </option>
+              </select>
+            </div>
+          </div>
+          <div v-if="uniqueCrsTypes.length > 0" class="control">
+            <div class="select is-small">
+              <select v-model="filterCrs" title="Filter by CRS">
+                <option value="all">CRS: All</option>
+                <option v-for="v in uniqueCrsTypes" :key="v" :value="v">
+                  {{ v }}
+                </option>
+              </select>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="catalog-entries">
+      <p v-if="filteredDatasets.length === 0" class="has-text-grey is-size-7">
+        No datasets match your search.
+      </p>
+      <div
+        v-for="(entry, i) in filteredDatasets"
+        :key="entry.url + '-' + i"
+        class="catalog-entry panel-block"
+      >
+        <button
+          class="catalog-entry-select"
+          type="button"
+          @click="select(entry)"
+        >
+          <div class="catalog-entry-content">
+            <div class="catalog-entry-header">
+              <div class="catalog-entry-main">
+                <span class="icon is-small has-text-link">
+                  <i class="fa-solid fa-database"></i>
+                </span>
+                <div class="catalog-entry-text">
+                  <strong
+                    class="catalog-entry-title"
+                    :title="displayTitle(entry)"
+                  >
+                    {{ displayTitle(entry) }}
+                  </strong>
+                </div>
+              </div>
+            </div>
+            <p v-if="entry.description" class="help has-text-grey mt-1 mb-0">
+              {{ entry.description }}
+            </p>
+          </div>
+        </button>
+        <div class="catalog-entry-tags-row">
+          <div class="catalog-entry-tags">
+            <span v-if="entry.format" class="tag is-info is-light is-small">
+              {{ entry.format }}
+            </span>
+            <span v-if="entry.access" class="tag is-warning is-light is-small">
+              {{ entry.access }}
+            </span>
+            <span v-if="entry.layout" class="tag is-light is-small">
+              {{ entry.layout }}
+            </span>
+            <span v-if="entry.grid" class="tag is-link is-light is-small">
+              {{ entry.grid }}
+            </span>
+            <span
+              v-if="entry.convention"
+              class="tag is-primary is-light is-small"
+            >
+              {{ entry.convention }}
+            </span>
+            <span v-if="entry.crs" class="tag is-success is-light is-small">
+              {{ entry.crs }}
+            </span>
+            <button
+              type="button"
+              class="tag is-light is-small catalog-copy-tag"
+              :aria-label="`Copy URL for ${displayTitle(entry)}`"
+              @click.stop.prevent="copyUrl(entry.url)"
+            >
+              {{
+                copiedUrl === entry.url
+                  ? "Copied URL"
+                  : copyFailedUrl === entry.url
+                    ? "Copy failed"
+                    : "Copy URL"
+              }}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </nav>
+</template>
+
+<style lang="scss" scoped>
+.catalog-title {
+  color: var(--bulma-label-color);
+  display: block;
+  font-size: var(--bulma-size-normal);
+  font-weight: var(--bulma-weight-semibold);
+}
+.catalog-panel {
+  margin-top: 1rem;
+  max-height: 400px;
+}
+
+.catalog-entries {
+  max-height: 45vh;
+  overflow-y: auto;
+  scrollbar-width: thin;
+}
+
+.catalog-entry {
+  display: flex !important;
+  flex-direction: column;
+  width: 100%;
+  border-bottom: 1px solid var(--bulma-border);
+  &:last-child {
+    border-bottom: none;
+  }
+}
+
+.catalog-entry-select {
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font: inherit;
+  color: inherit;
+  padding: 0;
+  &:hover {
+    background-color: var(--bulma-link-light);
+  }
+  &:focus-visible {
+    outline: 2px solid var(--bulma-link);
+    outline-offset: 2px;
+  }
+}
+
+.catalog-entry-content {
+  width: 100%;
+  min-width: 0;
+}
+
+.catalog-entry-header {
+  display: flex;
+  gap: 0.5rem;
+  min-width: 0;
+}
+
+.catalog-entry-main {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.catalog-entry-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.catalog-entry-tags-row {
+  margin-top: 0.35rem;
+}
+
+.catalog-entry-tags {
+  display: flex;
+  gap: 0.25rem;
+  flex-wrap: wrap;
+}
+
+.catalog-copy-tag {
+  cursor: pointer;
+  border: none;
+  &:hover {
+    background-color: var(--bulma-link-light);
+  }
+  &:active {
+    filter: brightness(0.95);
+  }
+  &:focus-visible {
+    outline: 2px solid var(--bulma-link);
+    outline-offset: 2px;
+  }
+}
+
+.catalog-filters {
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  row-gap: 0.25rem;
+}
+
+.catalog-entry-title {
+  display: block;
+  min-width: 0;
+  white-space: normal;
+  word-break: break-word;
+}
+</style>

--- a/src/utils/catalog.ts
+++ b/src/utils/catalog.ts
@@ -5,6 +5,12 @@ export type TCatalogEntry = {
   title?: string;
   tag?: string;
   description?: string;
+  format?: string;
+  access?: string;
+  layout?: string;
+  grid?: string;
+  convention?: string | null;
+  crs?: string;
 };
 
 export type TCatalog = {

--- a/src/views/HashGlobeView.vue
+++ b/src/views/HashGlobeView.vue
@@ -15,10 +15,11 @@ import type { TURLParameterValues } from "@/utils/urlParams.ts";
 
 type TParams = Partial<Record<TURLParameterValues, string>>;
 
+// Keep in sync with the first entry of DEFAULT_CATALOG.
 const DEFAULT_DATASET =
-  "https://storage.googleapis.com/cmip6/CMIP6/ScenarioMIP/AWI/AWI-CM-1-1-MR/ssp585/r1i1p1f1/day/sfcWind/gn/v20190529/";
+  "https://ogs-arco-ocean.s3.eu-south-1.amazonaws.com/dataset/tres=1d/res=0p25/levels=10/";
 
-const DEFAULT_CATALOG = "static/catalog.json";
+const DEFAULT_CATALOG = "static/catalog-extended.json";
 
 const defaultSrc = ref(DEFAULT_DATASET);
 const src = ref(DEFAULT_DATASET);

--- a/vite.jupyter.config.ts
+++ b/vite.jupyter.config.ts
@@ -1,0 +1,25 @@
+import { mergeConfig } from "vite";
+
+import baseConfig from "./vite.config.ts";
+
+// Fork-only config for running `vite` behind jupyter-server-proxy on a
+// JupyterHub. Extends the standard config and:
+//   - sets `base` to the proxied path so Vite's injected URLs
+//     (`/@vite/client`, HMR websocket, module IDs) go through the proxy
+//     instead of hitting the hub root
+//   - binds to 0.0.0.0 so the hub proxy can reach the dev server
+//   - disables the Vite 8 host allowlist (hub URL is not localhost)
+// Invoke with: `npm run dev -- -c vite.jupyter.config.ts`
+const port = 3000;
+const servicePrefix = process.env.JUPYTERHUB_SERVICE_PREFIX ?? "/";
+const base = `${servicePrefix}proxy/${port}/`;
+
+export default mergeConfig(baseConfig, {
+  base,
+  server: {
+    host: true,
+    port,
+    strictPort: true,
+    allowedHosts: true,
+  },
+});

--- a/vite.jupyter.config.ts
+++ b/vite.jupyter.config.ts
@@ -2,24 +2,35 @@ import { mergeConfig } from "vite";
 
 import baseConfig from "./vite.config.ts";
 
-// Fork-only config for running `vite` behind jupyter-server-proxy on a
-// JupyterHub. Extends the standard config and:
-//   - sets `base` to the proxied path so Vite's injected URLs
-//     (`/@vite/client`, HMR websocket, module IDs) go through the proxy
-//     instead of hitting the hub root
+// Fork-only companion to vite.config.ts. When running inside a
+// JupyterHub single-user server it:
+//   - sets `base` to the proxy path Vite is served at (via
+//     jupyter-server-proxy's `absolute` mode) so Vite's injected URLs
+//     (`/@vite/client`, HMR websocket, module IDs) resolve through the
+//     hub proxy instead of the hub root
 //   - binds to 0.0.0.0 so the hub proxy can reach the dev server
 //   - disables the Vite 8 host allowlist (hub URL is not localhost)
-// Invoke with: `npm run dev -- -c vite.jupyter.config.ts`
+// Detection is by JUPYTERHUB_SERVICE_PREFIX. Off-hub this file is a
+// no-op that merges an empty object with the standard config, so it
+// is safe to point `npm run dev` at it unconditionally.
+//
+// Access with the `absolute` variant, which preserves the full path
+// instead of stripping the proxy prefix. The stripping variant causes
+// a redirect loop with Vite's subpath `base`:
+//   https://<hub-host>${JUPYTERHUB_SERVICE_PREFIX}proxy/absolute/3000/
+const servicePrefix = process.env.JUPYTERHUB_SERVICE_PREFIX;
 const port = 3000;
-const servicePrefix = process.env.JUPYTERHUB_SERVICE_PREFIX ?? "/";
-const base = `${servicePrefix}proxy/${port}/`;
 
-export default mergeConfig(baseConfig, {
-  base,
-  server: {
-    host: true,
-    port,
-    strictPort: true,
-    allowedHosts: true,
-  },
-});
+const overrides = servicePrefix
+  ? {
+      base: `${servicePrefix}proxy/absolute/${port}/`,
+      server: {
+        host: true,
+        port,
+        strictPort: true,
+        allowedHosts: true,
+      },
+    }
+  : {};
+
+export default mergeConfig(baseConfig, overrides);


### PR DESCRIPTION
Ports the extended catalog filter UI from `eeholmes/gridlook-xl` and wires it in as the default catalog for this fork, so datasets can be filtered by format / access / layout / grid / convention / CRS while integrating other pieces from the fork.

Closes #2.

## What's in this PR

- **Feature** — `CatalogPanelExtended.vue` (new file) implements the six filter dropdowns, per-entry tag pills, and Copy URL button (strips `::…` state and `icechunk+`). `CatalogPanel.vue` gains a 15-line delegation shim: if any entry has any extended field, render `CatalogPanelExtended`; otherwise render the existing panel unchanged.
- **Type** — `TCatalogEntry` in `src/utils/catalog.ts` gains optional `format/access/layout/grid/convention/crs` alongside the existing `tag`. Additive only.
- **Defaults** — `DEFAULT_CATALOG` now points at `static/catalog-extended.json`, and `DEFAULT_DATASET` is the first entry of that catalog (kept in sync manually — comment reminds).
- **Extended catalog** — `public/static/catalog-extended.json` (new) is Eli's tested extended-schema catalog from gridlook-xl, verbatim.
- **Docs** — `docs/catalogs-extended.md` (new) documents the extended schema. Upstream `docs/catalogs.md` untouched.
- **Dev tooling** — `vite.jupyter.config.ts` (new, fork-only) is a hub-aware wrapper that, when `JUPYTERHUB_SERVICE_PREFIX` is set, sets `base` to the proxied path, binds 0.0.0.0, allows all hosts, and pins port 3000. Off-hub it's a no-op. The `dev` npm script now uses this config unconditionally.
- **Chore** — `.gitignore` gains `.ipynb_checkpoints/`.

## Merge-conflict surface with upstream

Deliberately minimal — this branch is unlikely to ever land upstream, and Eli will keep merging upstream `main` into this fork.

| Upstream file | Diff |
| --- | --- |
| `src/utils/catalog.ts` | +6 lines (additive, `tag` kept) |
| `src/ui/overlays/controls/CatalogPanel.vue` | +15 / -1 (delegation shim, existing markup untouched) |
| `src/views/HashGlobeView.vue` | 3 lines (default catalog + default dataset + a comment) |
| `package.json` | 1 line (`dev` script uses jupyter config) |
| `.gitignore` | +3 lines (Jupyter checkpoints) |

Everything else is fork-only new files: `CatalogPanelExtended.vue`, `catalog-extended.json`, `docs/catalogs-extended.md`, `vite.jupyter.config.ts`.

`public/static/catalog.json` and `docs/catalogs.md` are **not** touched, so upstream's evolution of the default catalog and its docs will merge cleanly.

## Test plan

- [x] `npm run lint`, `npm run typecheck`, `npm run test` (89/89), `npm run build` all pass
- [x] Default catalog loads on page start with the six filter dropdowns visible
- [x] First entry of the catalog renders as the demo globe
- [x] `npm run dev` works from a JupyterHub single-user server via `https://<hub-host>${JUPYTERHUB_SERVICE_PREFIX}proxy/absolute/3000/`
- [x] Off-hub `npm run dev` still works (jupyter config is no-op without `JUPYTERHUB_SERVICE_PREFIX`)
