### PR TITLE
fix(lib): diagnose Icechunk virtual chunks blocked by CORS

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,8 @@ model (ESM) output on native grids.
   required by live mode.
 - [CORS and data hosting](../README.md#cors--hosting-notes) — browser access
   requirements and a header check.
+- [Icechunk virtual chunks and CORS](icechunk-virtual-chunks.md) — why a
+  repository can index but not plot, and how to work around it.
 
 ## Capabilities
 

--- a/docs/icechunk-virtual-chunks.md
+++ b/docs/icechunk-virtual-chunks.md
@@ -1,0 +1,71 @@
+# Icechunk virtual chunks and CORS
+
+Some Icechunk repositories do not store their array bytes at all. Instead the
+repository records only metadata plus byte-range references — file, offset,
+length — into the original NetCDF, HDF5 or GRIB files wherever they were first
+published. These are **virtual chunks**, and they are what tools such as
+[VirtualiZarr](https://github.com/zarr-developers/VirtualiZarr) produce.
+
+Virtual chunks are cheap to publish, because no data is copied. The cost is that
+reading them pulls bytes from a _second_ host, and Gridlook runs in a browser.
+
+## Why a repository can index but not plot
+
+Opening such a repository in Gridlook can look like a partial success:
+
+- The variable list, dimensions, attributes and grid type all appear, because
+  that metadata lives in the Icechunk repository itself.
+- Coordinate variables often plot fine too. Writers commonly pass `time`,
+  `latitude` and `longitude` as `loadable_variables`, which materialises them as
+  ordinary chunks inside the repository.
+- Every data variable fails, because only those chunks are virtual.
+
+The browser must fetch a virtual chunk with a cross-origin range request, and it
+will only hand the response to Gridlook if the host that serves the bytes
+returns an `Access-Control-Allow-Origin` header. Many data archives serve the
+bytes perfectly well to `curl`, `wget` or Python and send no CORS headers at
+all. In that case the browser discards the response before Gridlook sees it, and
+`fetch` rejects with an opaque `TypeError: Failed to fetch`.
+
+Gridlook rewrites that rejection into a message naming the offending host, so
+the toast tells you _which_ server refused rather than only that something did.
+
+## Checking a host
+
+Ask for a byte range and look for the CORS header. Send an `Origin`, because
+some servers only add the header when one is present:
+
+```sh
+curl -sS -o /dev/null -D- -r 0-99 \
+  -H "Origin: https://gridlook.pages.dev" \
+  "https://example.org/path/to/file.nc" \
+  | grep -iE "^HTTP|access-control-allow-origin"
+```
+
+A usable host answers `206 Partial Content` **and** an
+`access-control-allow-origin` line. A `206` with no such line is the failure
+case described above. Note that a plain `curl` without `-H "User-Agent: ..."`
+can also hit user-agent filtering that a real browser never sees, so a `403`
+here does not necessarily mean the browser would get one.
+
+## Working around a host without CORS
+
+- **Install a CORS-unblocking browser extension.** This is the quickest fix and
+  the only one a reader can apply on their own. Such extensions inject
+  `Access-Control-Allow-Origin` into responses, which is all that is missing —
+  Gridlook sends only a `Range` header on virtual-chunk requests, and `Range` is
+  CORS-safelisted, so no preflight is involved. Treat it as a per-session
+  debugging tool: it weakens a browser security boundary for every site you
+  visit while it is enabled.
+- **Republish the repository with materialised chunks.** The durable fix. Write
+  the data into the Icechunk repository rather than referencing it, so every
+  chunk is served by the repository host. Object stores used for public data
+  usually already send `Access-Control-Allow-Origin: *`.
+- **Serve the referenced files from a CORS-enabled host.** Keeps the repository
+  virtual and fixes it for every reader, but requires control over, or a mirror
+  of, the source archive.
+
+## Related
+
+- [CORS and data hosting](../README.md#cors--hosting-notes) — the same
+  requirement for ordinary Zarr stores.

--- a/src/lib/data/icechunkStore.ts
+++ b/src/lib/data/icechunkStore.ts
@@ -1,6 +1,8 @@
 import { IcechunkStore } from "icechunk-js";
 import * as zarr from "zarrita";
 
+import { virtualChunkFetchClient } from "./virtualChunkFetch.ts";
+
 const ICECHUNK_PREFIX = "icechunk+";
 
 type TIcechunkStore = zarr.AsyncReadable & Pick<IcechunkStore, "listNodes">;
@@ -39,7 +41,9 @@ export function isIcechunkStorePath(storePath: string) {
 export async function createIcechunkStore(
   storePath: string
 ): Promise<TIcechunkStore> {
-  return await IcechunkStore.open(parseStorePath(storePath).url);
+  return await IcechunkStore.open(parseStorePath(storePath).url, {
+    fetchClient: virtualChunkFetchClient,
+  });
 }
 
 export async function createListableIcechunkStore(storePath: string) {

--- a/src/lib/data/virtualChunkFetch.ts
+++ b/src/lib/data/virtualChunkFetch.ts
@@ -1,0 +1,84 @@
+import type { FetchClient } from "icechunk-js";
+
+import { getErrorMessage } from "@/utils/errorHandling.ts";
+
+/**
+ * Icechunk repositories may store *virtual* chunks: the repository holds only
+ * the metadata and byte-range references, while the array bytes stay in the
+ * original files on whichever host published them. Reading such a chunk is a
+ * cross-origin range request, which a browser only completes if that host
+ * returns CORS headers. Plenty of archives serve the bytes happily to `curl`
+ * yet send no `Access-Control-Allow-Origin`, so the browser discards the
+ * response before any code sees it and `fetch` rejects with a bare
+ * `TypeError: Failed to fetch` that names neither the host nor the cause.
+ *
+ * The client below leaves the request itself untouched — icechunk-js still
+ * builds the `Range` header and handles redirects — and only rewrites that
+ * opaque rejection into a message that says which host refused and what a
+ * reader can do about it.
+ */
+const VIRTUAL_CHUNK_DOC = "docs/icechunk-virtual-chunks.md";
+
+function hostOf(url: string) {
+  try {
+    return new URL(url).host;
+  } catch {
+    return url;
+  }
+}
+
+function isCrossOrigin(url: string) {
+  const origin = globalThis.location?.origin;
+  if (!origin) {
+    // Outside a browser there is no origin to compare against, and no CORS.
+    return false;
+  }
+  try {
+    return new URL(url, origin).origin !== origin;
+  } catch {
+    return false;
+  }
+}
+
+function isAbort(error: unknown) {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    (error as { name?: unknown }).name === "AbortError"
+  );
+}
+
+export function describeVirtualChunkFetchFailure(url: string, cause: unknown) {
+  const host = hostOf(url);
+  const detail = getErrorMessage(cause);
+  if (!isCrossOrigin(url)) {
+    return `Could not read Icechunk virtual chunks from ${host}: ${detail}`;
+  }
+  return (
+    `Icechunk virtual chunks live on ${host}, and the browser blocked the ` +
+    `request — usually because that host sends no CORS headers. A ` +
+    `CORS-unblocking browser extension works around it; see ` +
+    `${VIRTUAL_CHUNK_DOC}. (${detail})`
+  );
+}
+
+class VirtualChunkFetchClient implements FetchClient {
+  async fetch(url: string, init?: RequestInit): Promise<Response> {
+    try {
+      return await fetch(url, init);
+    } catch (cause) {
+      if (isAbort(cause)) {
+        throw cause;
+      }
+      throw new Error(describeVirtualChunkFetchFailure(url, cause), { cause });
+    }
+  }
+}
+
+/**
+ * A single shared instance: icechunk-js keys its in-flight request cache on the
+ * identity of the client, so handing out a fresh object per store would defeat
+ * that cache.
+ */
+export const virtualChunkFetchClient: FetchClient =
+  new VirtualChunkFetchClient();

--- a/tests/unit/lib/data/virtualChunkFetch.test.ts
+++ b/tests/unit/lib/data/virtualChunkFetch.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  describeVirtualChunkFetchFailure,
+  virtualChunkFetchClient,
+} from "@/lib/data/virtualChunkFetch.ts";
+
+const CHUNK_URL =
+  "https://coastwatch.noaa.gov/pub/socd2/coastwatch/ocean_heat/na14/2025/ohc_na14QG3_2025_085.nc";
+
+function withOrigin(origin: string | undefined) {
+  if (origin === undefined) {
+    vi.stubGlobal("location", undefined);
+    return;
+  }
+  vi.stubGlobal("location", { origin });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("describeVirtualChunkFetchFailure", () => {
+  it("names the host and the CORS workaround for a cross-origin chunk", () => {
+    withOrigin("https://example.org");
+    const message = describeVirtualChunkFetchFailure(
+      CHUNK_URL,
+      new TypeError("Failed to fetch")
+    );
+    expect(message).toContain("coastwatch.noaa.gov");
+    expect(message).toContain("CORS");
+    expect(message).toContain("docs/icechunk-virtual-chunks.md");
+    expect(message).toContain("Failed to fetch");
+  });
+
+  it("does not blame CORS when the chunk is same-origin", () => {
+    withOrigin("https://coastwatch.noaa.gov");
+    const message = describeVirtualChunkFetchFailure(
+      CHUNK_URL,
+      new TypeError("Failed to fetch")
+    );
+    expect(message).toContain("coastwatch.noaa.gov");
+    expect(message).not.toContain("CORS");
+  });
+
+  it("does not blame CORS outside a browser", () => {
+    withOrigin(undefined);
+    const message = describeVirtualChunkFetchFailure(
+      CHUNK_URL,
+      new TypeError("Failed to fetch")
+    );
+    expect(message).not.toContain("CORS");
+  });
+
+  it("falls back to the raw url when it cannot be parsed", () => {
+    withOrigin("https://example.org");
+    const message = describeVirtualChunkFetchFailure(
+      "not a url",
+      new TypeError("Failed to fetch")
+    );
+    expect(message).toContain("not a url");
+  });
+});
+
+describe("virtualChunkFetchClient", () => {
+  it("passes successful responses through untouched", async () => {
+    const response = new Response("ok", { status: 206 });
+    const fetchSpy = vi.fn().mockResolvedValue(response);
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const init = { headers: { Range: "bytes=0-99" } };
+    await expect(virtualChunkFetchClient.fetch(CHUNK_URL, init)).resolves.toBe(
+      response
+    );
+    expect(fetchSpy).toHaveBeenCalledWith(CHUNK_URL, init);
+  });
+
+  it("passes error responses through rather than rewriting them", async () => {
+    const response = new Response("nope", { status: 403 });
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(response));
+
+    await expect(virtualChunkFetchClient.fetch(CHUNK_URL)).resolves.toBe(
+      response
+    );
+  });
+
+  it("rewrites an opaque network rejection into a diagnosis", async () => {
+    withOrigin("https://example.org");
+    const cause = new TypeError("Failed to fetch");
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(cause));
+
+    await expect(
+      virtualChunkFetchClient.fetch(CHUNK_URL)
+    ).rejects.toMatchObject({
+      message: expect.stringContaining("coastwatch.noaa.gov"),
+      cause,
+    });
+  });
+
+  it("lets an aborted request through unchanged", async () => {
+    const abort = new DOMException("aborted", "AbortError");
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(abort));
+
+    await expect(virtualChunkFetchClient.fetch(CHUNK_URL)).rejects.toBe(abort);
+  });
+});


### PR DESCRIPTION
Fixes the unhelpful error reported in #7, where
`https://data.source.coop/fish-pace/coastwatch/ocean-heat/na/` failed with a
bare "Could not fetch data / Failed to fetch".

## What was actually wrong

Nothing in the data path. The repository opens fine, and every variable indexes
correctly. It is an Icechunk repository of *virtual* chunks: it stores only
byte-range references into the original NetCDF files, which live on
`coastwatch.noaa.gov`. The coordinate variables were written as
`loadable_variables`, so they are materialised on source.coop (which sends
`access-control-allow-origin: *`) and load normally — but every data variable's
chunks are cross-origin range requests to a host that sends no CORS headers at
all. The browser discards the response before any code sees it, and `fetch`
rejects with a bare `TypeError: Failed to fetch` naming neither the host nor
the cause.

Confirmed out of band: NOAA serves the exact chunk range (`206`, correct
`Content-Range`) to a fully browser-shaped cross-site request, and still sends
no `Access-Control-Allow-Origin`. The missing header is the only blocker.

The hypothesis in #7 about custom HTTP headers does not apply — `User-Agent` is
a forbidden header in browsers, so icechunk's custom-header support cannot
help here.

## The change

A `FetchClient` that leaves the request completely untouched — icechunk-js
still builds the `Range` header and handles redirects — and only rewrites that
opaque rejection into a message naming the host and the likely cause:

> Icechunk virtual chunks live on coastwatch.noaa.gov, and the browser blocked
> the request — usually because that host sends no CORS headers. A
> CORS-unblocking browser extension works around it; see
> docs/icechunk-virtual-chunks.md.

Aborts and same-origin failures pass through unchanged.

This is diagnosis, not a workaround: the dataset still needs a CORS-unblocking
browser extension to load, which is the accepted approach for hosts we do not
control. `docs/icechunk-virtual-chunks.md` explains why a repository can index
but not plot, gives a `curl` recipe to check a host, and lists the options.

## Merge surface

Deliberately small, to stay easy to merge against d70-t/gridlook: seven lines
across two files upstream owns (`src/lib/data/icechunkStore.ts` +5/-1,
`docs/README.md` +2). Everything else is new files.

## Verification

`npm run lint-ci`, `npm run typecheck`, and `npm run build` all pass; 23 test
files / 112 tests pass, including 8 new ones covering the message, the
same-origin and non-browser cases, and pass-through of successes and aborts.

Closes #7
