### PR TITLE
Survey Zarr codec support and name the codec when a dataset cannot be decoded

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-> **Before starting new work, read [`claude/handoff.md`](./claude/handoff.md).** It carries the most recent session's state, what shipped, and the shortlist for next steps. The full archaeology of the `eeholmes/gridlook-xl` fork lives in [`claude/comparison.md`](./claude/comparison.md).
+> **Before starting new work, read [`claude/handoff.md`](./claude/handoff.md).** It carries the most recent session's state, what shipped, and the shortlist for next steps. The full archaeology of the `eeholmes/gridlook-xl` fork lives in [`claude/comparison.md`](./claude/comparison.md), and the surveyed state of Zarr codec and data-type support in [`claude/codec-support.md`](./claude/codec-support.md).
 
 ## Project Overview
 
@@ -25,7 +25,7 @@ npm run test:watch     # vitest in watch mode
 Run a single test file: `npx vitest run tests/unit/lib/data/gridTypeDetector.test.ts`
 Filter by test name: `npx vitest run -t "detects healpix"`
 
-Tests live in `tests/**/*.test.ts` and run in the `node` environment (see `vite.config.ts`).
+Tests live in `tests/**/*.test.ts` and run in the `node` environment (see `vite.config.ts`). Shared, non-test helpers go in `tests/helpers/`; `boundaries/ignore` in `eslint.config.js` covers `tests/**` so they do not trip `boundaries/no-unknown-files`. Zarr-reading tests build a synthetic in-memory store as a `Map` and open it with `open.v2`/`open.v3` rather than hitting the network — see `tests/unit/lib/data/logBins.test.ts` for the smallest example. Zarr metadata keys are snake_case, which the `camelcase` rule rejects, so write them as computed keys from a constant map.
 
 Node `>=24.16.0` is required (see `package.json` engines). On this JupyterHub machine Node lives at `~/.local/opt/node-v24.20.0-linux-x64`, symlinked into `~/.local/bin`, which `~/.bashrc` prepends to `PATH`. The home directory persists across hubs, so a "new machine" almost never needs a reinstall — if `npm` appears missing, suspect the shell before reinstalling anything. Login shells (what the JupyterHub terminal spawns) read `~/.bash_profile`, not `~/.bashrc`, so a `~/.bash_profile` that sources `~/.bashrc` is in place to bridge that. Non-interactive tool shells may still miss it, in which case prepend `export PATH="$HOME/.local/opt/node-v24.20.0-linux-x64/bin:$PATH"` explicitly. Husky installs on `npm install`: `pre-commit` runs `lint-staged` (ESLint --fix + Prettier) then `npm run typecheck`; `commit-msg` runs Commitlint.
 
@@ -81,6 +81,16 @@ Each grid family under `src/lib/grids/` follows a consistent pattern of three fi
 Icechunk repositories may hold _virtual_ chunks: the repository stores only byte-range references into the original NetCDF/HDF5 files, which stay on whichever host published them. Reading one is a cross-origin range request, and plenty of archives (`coastwatch.noaa.gov`, for one) serve those bytes happily to `curl` while sending no `Access-Control-Allow-Origin`, so the browser discards the response and `fetch` rejects with a bare `TypeError: Failed to fetch`. The tell is a dataset that indexes and lists its variables but fails on plot, often with the coordinates loading fine because they were written as `loadable_variables` and are therefore materialised. `src/lib/data/virtualChunkFetch.ts` rewrites that opaque rejection into a message naming the host; see `docs/icechunk-virtual-chunks.md`.
 
 The reader-side workaround is a CORS-unblocking browser extension (gridlook does not proxy). **Warn about the toggle before anything else:** in extensions of the "Allow CORS" family the switch reading `ON` means _CORS blocking is on_ — it has to be clicked to `OFF` to actually permit cross-origin reads. This is backwards from what the label suggests and has already cost debugging time once. If a reader says the extension is installed and enabled yet the data still will not load, check the toggle direction and force a hard reload (a cached `206` without CORS headers replays from cache without the extension ever running) before investigating anything in gridlook.
+
+### Codecs and data types
+
+Codec support comes from three stacked layers: `numcodecs.js` supplies the compiled compressors (blosc, lz4, zstd, gzip, zlib and nothing else), `zarrita` wires those in and adds the pure-JS v3 codecs, and `src/lib/data/codecs.ts` adds `fletcher32`, `gribscan.rawgrib`, `log_bins` and `pcodec`. Adding a codec means a new file shaped like `fletcher32.ts` plus one `registry.set` line — never a WebAssembly dependency in `src/lib`. When one is genuinely needed, the precedent is `@eeholmes/zarrita-pcodec`: a separate optional package registered through a lazy `() => import(...)` thunk, so the WebAssembly is fetched only if a dataset uses it. **[`claude/codec-support.md`](./claude/codec-support.md) is the surveyed inventory** of what decodes today, what does not, and which gaps belong to gridlook, zarrita or numcodecs.js.
+
+A codec gridlook cannot decode **never fails at open time**. The store opens, every variable lists, and the failure arrives on the first chunk read — indistinguishable at a glance from the CORS-blocked virtual chunks above. When triaging a dataset that lists its variables but will not plot, check the array metadata's codec list before suspecting the network.
+
+`src/lib/data/codecErrors.ts` turns those failures into a message naming the codec, and `useLog` applies it, so the call sites keep passing their own context strings unchanged. Two constraints if you extend it: the grid data worker flattens errors to a plain string before `postMessage`, so the error class and its fields are gone by the time one reaches the UI — classification must work on message text as well as structure — and anything zarrita puts on `cause` has to be appended explicitly (`flattenErrorMessage`) or it is lost.
+
+`codecErrors.ts` and `tests/unit/lib/data/codecErrors.test.ts` are kept **byte-identical** to the copies on the `fix/codec-error-messages` branch proposed upstream. Change one and you must change the other, or the next `git merge upstream/main` conflicts. That is also why the test inlines its fixtures rather than using `tests/helpers/zarrStoreFixtures.ts`, which is fork-only.
 
 ### Value transforms
 

--- a/claude/codec-support.md
+++ b/claude/codec-support.md
@@ -56,7 +56,7 @@ Three properties worth keeping:
 What this design deliberately does **not** do is hit real datasets. Network
 tests would make CI flaky and would conflate codec bugs with CORS and host
 outages — the failure mode that ate PR #8. Real URLs belong in the manual
-checklist in §5 instead.
+checklist in §6 instead.
 
 ---
 
@@ -82,14 +82,14 @@ Unregistered and reachable today: `fixedscaleoffset`, `quantize`, `astype`,
 
 The useful split is by what a decoder would cost:
 
-| Codec                 | Decode is…                                                                               | Plain JS?      |
-| --------------------- | ---------------------------------------------------------------------------------------- | -------------- |
-| `quantize`            | a dtype cast — the lossy step is encode-only                                             | trivial        |
-| `astype`              | a dtype cast                                                                             | trivial        |
-| `fixedscaleoffset`    | `value / scale + offset`; zarrita already has the pieces (`scale_offset` + `cast_value`) | trivial        |
-| `crc32`, `adler32`    | strip and verify 4 checksum bytes                                                        | small          |
-| `packbits`            | bit unpacking                                                                            | small          |
-| `bz2`, `lzma`, `zfpy` | a real decompressor                                                                      | **needs WASM** |
+| Codec                 | Decode is…                                                                                        | Plain JS?      |
+| --------------------- | ------------------------------------------------------------------------------------------------- | -------------- |
+| `quantize`            | a dtype cast — the lossy step is encode-only                                                      | trivial        |
+| `astype`              | a dtype cast                                                                                      | trivial        |
+| `fixedscaleoffset`    | `value / scale + offset`, then a cast; zarrita has both pieces but wires them only in its v2 path | yes, ~40 lines |
+| `crc32`, `adler32`    | strip and verify 4 checksum bytes                                                                 | small          |
+| `packbits`            | bit unpacking                                                                                     | small          |
+| `bz2`, `lzma`, `zfpy` | a real decompressor                                                                               | **needs WASM** |
 
 So most of the gap closes with plain JavaScript. Only the last row runs into
 upstream's no-WASM position, and none of those three is common in ESM output.
@@ -168,7 +168,108 @@ repos' installs reproducible. Not a gridlook code change at all.
 
 ---
 
-## 4. Options, if we decide to act
+## 4. Where each fix belongs
+
+Three possible homes, and the choice is not really about preference — it is
+about where the failing code lives and whether gridlook has a hook to reach it.
+
+| Problem                                                   | Best home                     | Why                                                                                         |
+| --------------------------------------------------------- | ----------------------------- | ------------------------------------------------------------------------------------------- |
+| P1 — `quantize`, `astype`, `packbits`, `crc32`, `adler32` | **gridlook**                  | The registry is the sanctioned extension point, and we already use it three times           |
+| P1 — `numcodecs.fixedscaleoffset` (v3 name)               | **zarrita** (gridlook viable) | zarrita already owns the mapping; duplicating it here means maintaining a second copy       |
+| P1 — `bz2`, `lzma`, `zfpy`                                | **numcodecs.js**              | They need a real decompressor; this is the gap Eli named in d70-t/gridlook#180              |
+| P2 — int64/uint64 variables                               | **gridlook**                  | zarrita is right to return `BigInt64Array`; the render pipeline decides what to do with it  |
+| P3 — string variables                                     | **gridlook**                  | Same: the data is decoded correctly, the display layer swallows it                          |
+| P4 — object-form `data_type`                              | **zarrita**                   | Crashes inside `open.v3` before gridlook sees anything, and there is no hook for data types |
+| P5 — float16 without `Float16Array`                       | **zarrita**                   | Same reason; gridlook could only polyfill a global, which is worse                          |
+| P6 — codec errors read as "Could not fetch data"          | **gridlook**                  | Purely presentation, at a boundary we own                                                   |
+| P7 — `github:` pcodec dependency                          | neither                       | It is a release chore in the `zarrita-pcodec` repo                                          |
+
+### Fix in gridlook — and the existing code to copy
+
+Each of these has a working example in the repository already, which is the
+main reason to prefer them: the shape is proven and upstream has accepted it.
+
+**Adding a codec (P1's plain-JS rows).** `src/lib/data/fletcher32.ts` is the
+template — a class with `kind`, `fromConfig`, `decode` and a stub `encode` that
+throws, registered with one `registry.set` line in `codecs.ts`. `logBins.ts` and
+`gribscan.ts` are the same pattern at larger sizes. Nothing about this touches
+zarrita: `registry` is public API, and zarrita issue #310 was closed precisely
+to make this the supported path. `quantize` and `astype` are almost free here
+because their decode is a dtype cast — the lossy work happens on encode, which
+we never do. `crc32` and `adler32` are `fletcher32.ts` with a different
+checksum.
+
+**Converting decoded arrays (P2, P3).** `src/lib/data/variableDecoding.ts` is
+the single funnel, and gridlook has already solved this exact conversion once:
+`toNumber` in `src/lib/data/timeHandling.ts` handles `bigint` and `string`
+for time coordinates, and `dimensionData.ts` carries a
+`number | bigint | string` coordinate type with explicit `UnicodeStringArray` /
+`ByteStringArray` branches. So the codebase already knows these arrays exist —
+it is only `castDataVarToFloat32` that assumes everything is a number. That
+makes P2/P3 a consistency fix rather than a new capability, which is a much
+easier argument to make upstream.
+
+**Improving the message (P6).** `src/lib/data/virtualChunkFetch.ts` from PR #8
+is the model: leave the behaviour completely untouched, catch the opaque error
+at the boundary, and rewrite it into something that names the cause. A codec
+equivalent would turn `UnknownCodecError` into a message naming the codec and
+pointing at re-encoding or a codec extension, and would unwrap
+`CodecPipelineError.cause` so checksum and truncation failures stop being
+swallowed by `getErrorMessage` in `src/utils/errorHandling.ts`.
+
+**If a WASM-only codec ever matters**, the precedent is `zarrita-pcodec`: a
+separate optional package, registered lazily in `codecs.ts`, so the WebAssembly
+never enters the bundle unless a dataset needs it. Do not vendor a decompressor
+into `src/lib`.
+
+### File upstream instead
+
+**P4 — object-form `data_type` → issue, and the PR is small.** This is the
+clearest upstream case. `zarrita` 0.7.4 assumes `data_type` is a string and
+calls `dataType.match(...)` inside its metadata parser, so the failure happens
+during `open.v3` before any gridlook code runs. There is no registry or hook to
+intercept it — the only workaround would be rewriting the metadata JSON before
+handing it to zarrita, which is exactly the kind of speculative parallel code
+path worth avoiding. Two details make this an easy report: the zarr v3 spec
+explicitly allows the object form, and it currently crashes even for
+`{"name": "float32"}`, a plain core type with no extension semantics at all. A
+`TypeError` rather than an `InvalidMetadataError` is itself a bug, since
+zarrita's own docs promise `isZarritaError` covers what it throws.
+
+**P1's `numcodecs.fixedscaleoffset` → issue, though we could patch locally.**
+Worth being precise about why this is not a one-line alias. zarrita represents
+the filter as two v3 codecs, `scale_offset` (array→array, dtype-preserving)
+followed by `cast_value`, and wires them up only inside `v2ToV3ArrayMetadata`.
+A registry entry for the single `numcodecs.fixedscaleoffset` name would have to
+do the divide-then-cast itself, so it is a ~40-line codec here rather than an
+alias — a second copy of a mapping zarrita already maintains. The better report
+is the asymmetry itself: **the same filter decodes under zarr v2 and fails
+under v3**, which is a self-evident inconsistency in zarrita rather than a
+feature request, and one fix there covers every zarrita consumer. The same
+argument extends to the other `numcodecs.zarr3` wrapper names, since
+zarr-python now writes them by default.
+
+**P5 — float16 → mention it, expect a "browsers have caught up" answer.**
+zarrita maps `float16` onto `globalThis.Float16Array` with no fallback, so on
+an older browser the array cannot be opened at all. It could fall back to a
+manual half-float decode — zarrita already handles the analogous case in
+`codecs/json-scalar.js`, where a missing `DataView.prototype.getFloat16` raises
+a clean `UnsupportedError` rather than crashing. Gridlook's only alternative
+would be polyfilling a global, which is worse than documenting the browser
+requirement. Low priority: the baseline is Chrome 135 / Firefox 129 / Safari 26,
+and it works end to end above that.
+
+**P1's `bz2`, `lzma`, `zfpy` → `manzt/numcodecs.js`, not zarrita.** These need
+real decompressors, and numcodecs.js is where the other compiled compressors
+live. This is the gap Eli already identified in d70-t/gridlook#180: nine
+compression codecs in the Python suite, five implemented in JavaScript. Filing
+there is more useful than filing against zarrita, which only wires up whatever
+numcodecs.js provides.
+
+---
+
+## 5. Options, if we decide to act
 
 Not implemented. Roughly ascending in cost, with merge surface against upstream:
 
@@ -177,8 +278,8 @@ Not implemented. Roughly ascending in cost, with merge surface against upstream:
    the dataset needs re-encoding or a codec extension, plus unwrapping
    `CodecPipelineError.cause`. Merge surface: a few lines at the catch site.
    This is exactly the PR #8 pattern.
-2. **Register the trivial v3 aliases** (P1, top three rows). `quantize`,
-   `astype` and `fixedscaleoffset` as small pure-JS codecs in new files, with
+2. **Register the trivial v3 codecs** (P1, top two rows). `quantize` and
+   `astype` as small pure-JS codecs in new files, with
    `codecs.ts` gaining one `registry.set` line each. Plain JS, no WASM, and
    directly upstreamable — it is the same shape as the existing `fletcher32.ts`.
 3. **Handle int64 and string variables explicitly** (P2, P3). Either convert
@@ -186,9 +287,14 @@ Not implemented. Roughly ascending in cost, with merge surface against upstream:
    clearly. Touches `castDataVarToFloat32`, which upstream owns — a few lines.
 4. **Checksum codecs** (`crc32`, `adler32`) — small, but no known ESM dataset
    here needs them yet. Probably not worth the diff until one shows up.
-5. **File the zarrita issue for object-form `data_type`** (P4). No gridlook
-   change; the fix belongs upstream of us.
-6. **Publish `zarrita-pcodec` to npm** (P7). Outside this repo.
+5. **File the zarrita issues** — object-form `data_type` (P4) first, since it is
+   an outright crash on spec-legal metadata, then the v2/v3 asymmetry for
+   `numcodecs.fixedscaleoffset` (P1). No gridlook change in either case; see §4
+   for why neither has a good local workaround.
+6. **File the numcodecs.js gap** for `bz2`, `lzma` and `zfpy` (P1, last row) —
+   the point Eli already made in d70-t/gridlook#180, in the repo that can act
+   on it.
+7. **Publish `zarrita-pcodec` to npm** (P7). Outside this repo.
 
 The one thing that clearly should **not** happen is pulling `bz2`, `lzma` or
 `zfpy` into gridlook as WebAssembly. If any of those ever matters, the pcodec
@@ -196,7 +302,7 @@ precedent applies: a separate optional package, lazily loaded.
 
 ---
 
-## 5. Manual checklist for real datasets
+## 6. Manual checklist for real datasets
 
 Deliberately not in CI. Run by hand when touching this area:
 
@@ -211,7 +317,7 @@ suspecting the network — §3's last bullet explains why the two look alike.
 
 ---
 
-## 6. Note on the one file this branch touches that upstream owns
+## 7. Note on the one file this branch touches that upstream owns
 
 `eslint.config.js`, one line: `"tests/**"` added to `boundaries/ignore`, so the
 shared fixture helper under `tests/helpers/` does not trip

--- a/claude/codec-support.md
+++ b/claude/codec-support.md
@@ -56,7 +56,7 @@ Three properties worth keeping:
 What this design deliberately does **not** do is hit real datasets. Network
 tests would make CI flaky and would conflate codec bugs with CORS and host
 outages — the failure mode that ate PR #8. Real URLs belong in the manual
-checklist in §6 instead.
+checklist in §7 instead.
 
 ---
 
@@ -302,7 +302,50 @@ precedent applies: a separate optional package, lazily loaded.
 
 ---
 
-## 6. Manual checklist for real datasets
+## 6. Packaging the error-message change as an upstream PR
+
+Upstream's testing philosophy is not ambiguous, so this is settled rather than
+a judgement call:
+
+- `.github/workflows/lint.yml` runs `lint-ci`, `typecheck`, **`npm run test`**
+  and `build` on every push and pull request. Tests gate the merge.
+- Upstream carries 20 test files, and they are not limited to pure geometry —
+  `tests/unit/ui/grids/composables/useGridDataLoader.test.ts` and
+  `tests/unit/utils/toast.test.ts` cover exactly the composable-and-toast layer
+  this change touches.
+- Of the last twelve merged PRs, every substantive one changed `tests/`. The
+  four that did not are two Release Please release commits, a `docs:` PR and a
+  rebase.
+
+So the PR should include tests. Two refinements worth making first:
+
+**Send only `codecErrors.test.ts`.** The survey tests from §2
+(`codecSupport`, `dataTypeSupport`, `pcodecSupport`) assert _gaps_ — they
+encode a list of problems the maintainers have not yet agreed are problems, and
+dropping that into a PR about error messages invites a scope argument. They
+belong in the fork, or attached as evidence to an issue. The error-message PR
+should test only what it adds.
+
+**Inline the fixtures and the PR touches no config at all.**
+`codecErrors.test.ts` uses `base64Bytes`, `v2ArrayMetadata` and `v2Store` from
+`tests/helpers/zarrStoreFixtures.ts`, and that shared helper is the only reason
+this branch edits `eslint.config.js` (§8). Upstream's own
+`tests/unit/lib/data/logBins.test.ts` already builds a synthetic v2 store
+inline as a `Map`, with the same computed-key trick for snake_case metadata
+names — so inlining is both about 25 lines and a closer match to house style.
+That removes the `tests/helpers/` directory and the `boundaries/ignore` line
+from the PR, leaving it as one new source file, one new test file, and 13 lines
+across two files upstream owns.
+
+One thing that needs no attention: upstream's `useGridDataLoader.test.ts`
+asserts `logError` was called with `"Could not fetch data"`. Because the
+explanation is applied inside `useLog` rather than at the call sites, that
+assertion is untouched and still passes — which is a point in favour of the
+hook location if a reviewer asks.
+
+---
+
+## 7. Manual checklist for real datasets
 
 Deliberately not in CI. Run by hand when touching this area:
 
@@ -317,7 +360,7 @@ suspecting the network — §3's last bullet explains why the two look alike.
 
 ---
 
-## 7. Note on the one file this branch touches that upstream owns
+## 8. Note on the one file this branch touches that upstream owns
 
 `eslint.config.js`, one line: `"tests/**"` added to `boundaries/ignore`, so the
 shared fixture helper under `tests/helpers/` does not trip

--- a/claude/codec-support.md
+++ b/claude/codec-support.md
@@ -1,0 +1,220 @@
+# Codec and format support — findings and plan (issue #5)
+
+Branch: `feat/codec-support-research`. **No fixes implemented** — this is the
+survey, the test harness, and the problem list, as issue #5 asked for.
+
+Everything below was measured, not inferred: the numbers come from probing
+`zarrita` 0.7.4 as it is installed here, and the byte fixtures come from Python
+`numcodecs` 0.16.5 and `zarr` 3.3.0 on this machine.
+
+---
+
+## 1. Where codec support actually comes from
+
+Three layers stack up, and only the third is ours:
+
+| Layer                    | What it contributes                                                                                                                                                                                      |
+| ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `numcodecs.js` 0.3.2     | The compiled compressors: **blosc, lz4, zstd, gzip, zlib**. Nothing else. Its README says so.                                                                                                            |
+| `zarrita` 0.7.4          | Wires those in, adds pure-JS `bytes`, `transpose`, `crc32c`, `vlen-utf8`, `json2`, `bitround`, `delta`, `shuffle`, `cast_value`, `scale_offset`, plus `sharding_indexed` (handled outside the registry). |
+| `src/lib/data/codecs.ts` | Adds `fletcher32`, `gribscan.rawgrib`, `log_bins`, and `pcodec` (via `@eeholmes/zarrita-pcodec`).                                                                                                        |
+
+`src/lib/data/codecs.ts` is **byte-identical to upstream's** — d70-t/gridlook
+already carries the pcodec package Eli built for #180, so codec support is not
+a fork divergence. Anything done here is a candidate for upstream directly.
+
+**pcodec's WebAssembly is already lazy.** `registerPCodec` only stores a
+`() => import("./PCodec.js")` thunk, so the 580 kB `pcodec.wasm` is fetched the
+first time a pcodec chunk is decoded and never otherwise. That is the answer to
+the objection in d70-t/gridlook#180, and it is now pinned by a test.
+
+---
+
+## 2. The test harness (this is the "how to test" answer)
+
+Three new test files, 88 new assertions, no network, no fixtures on disk.
+
+| File                                          | Covers                                                                                                                   |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `tests/unit/lib/data/codecSupport.test.ts`    | Decode of golden chunks per codec; the unregistered set; the registry inventory; zarr v3 stores written by zarr-python 3 |
+| `tests/unit/lib/data/pcodecSupport.test.ts`   | pcodec end-to-end through zarrita, v2 and v3                                                                             |
+| `tests/unit/lib/data/dataTypeSupport.test.ts` | What happens after decompression: dtypes, `castDataVarToFloat32`, float16 browser support                                |
+| `tests/helpers/zarrStoreFixtures.ts`          | Builds in-memory v2/v3 stores; a `getRange`-capable store for sharding                                                   |
+
+Three properties worth keeping:
+
+- **Golden bytes come from the reference encoder.** Every chunk literal was
+  produced by Python `numcodecs`/`zarr` (the recipe is in the file header), so a
+  green test means gridlook agrees with what publishers actually write — not
+  merely that our decoder round-trips against itself.
+- **The gaps are asserted, not omitted.** A codec we cannot decode has a test
+  saying so. When one gets registered, that test fails and someone has to update
+  it deliberately. The suite is a support inventory, not just a regression net.
+- **The registry inventory test catches zarrita upgrades.** If a `zarrita` bump
+  adds or drops a codec, `codecSupport.test.ts` says which one, by name.
+
+What this design deliberately does **not** do is hit real datasets. Network
+tests would make CI flaky and would conflate codec bugs with CORS and host
+outages — the failure mode that ate PR #8. Real URLs belong in the manual
+checklist in §5 instead.
+
+---
+
+## 3. Problem list
+
+Ordered by how likely a reader is to hit it.
+
+### P1 — zarr v3 `numcodecs.*` codec names are unregistered (high)
+
+zarr-python 3 writes codec names like `numcodecs.fixedscaleoffset` and
+`numcodecs.quantize` straight into v3 `zarr.json`. zarrita registers only ten
+`numcodecs.` aliases, so the rest fail. Verified against metadata actually
+written by zarr 3.3.0.
+
+The sharp edge: **`fixedscaleoffset` decodes under zarr v2 and fails under
+v3.** zarrita translates it during v2→v3 metadata conversion but never puts the
+name in the registry, so whether a dataset loads depends on which format it was
+written in. Same data, same filter, different outcome.
+
+Unregistered and reachable today: `fixedscaleoffset`, `quantize`, `astype`,
+`packbits`, `crc32`, `crc32c`, `adler32`, `jenkins_lookup3`, `bz2`, `lzma`,
+`zfpy`, `vlen-bytes`, `vlen-array`, `categorize`.
+
+The useful split is by what a decoder would cost:
+
+| Codec                 | Decode is…                                                                               | Plain JS?      |
+| --------------------- | ---------------------------------------------------------------------------------------- | -------------- |
+| `quantize`            | a dtype cast — the lossy step is encode-only                                             | trivial        |
+| `astype`              | a dtype cast                                                                             | trivial        |
+| `fixedscaleoffset`    | `value / scale + offset`; zarrita already has the pieces (`scale_offset` + `cast_value`) | trivial        |
+| `crc32`, `adler32`    | strip and verify 4 checksum bytes                                                        | small          |
+| `packbits`            | bit unpacking                                                                            | small          |
+| `bz2`, `lzma`, `zfpy` | a real decompressor                                                                      | **needs WASM** |
+
+So most of the gap closes with plain JavaScript. Only the last row runs into
+upstream's no-WASM position, and none of those three is common in ESM output.
+
+### P2 — int64/uint64 variables throw an opaque TypeError (medium)
+
+`castDataVarToFloat32` is `Float32Array.from(rawData)`, which refuses BigInt
+outright. An `int64` data variable produces **"Cannot convert a BigInt value to
+a number"** in a toast titled "Could not fetch data" — nothing names the data
+type or the variable. A one-line BigInt branch would fix the conversion; the
+question is whether to do that or to reject the variable with a clear message.
+
+### P3 — string variables render as a silent blank (medium)
+
+A `vlen-utf8` or fixed-width string variable decodes fine, then
+`Float32Array.from(["a", "b"])` yields all-NaN. No error, no toast — an empty
+globe and no explanation. Arguably worse than P2, because nothing at all tells
+the reader what happened.
+
+### P4 — `data_type` written as an object crashes (medium)
+
+The zarr v3 spec allows `"data_type": {"name": ..., "configuration": ...}`,
+which is how zarr-python writes extension types such as `numpy.datetime64`.
+zarrita 0.7.4 assumes a string and calls `dataType.match(...)`, so the failure
+is a bare `TypeError: dataType.match is not a function` — not even a zarrita
+error, so `isZarritaError` cannot classify it and no message explains it. This
+is an upstream zarrita bug and probably wants an issue at `manzt/zarrita.js`.
+It overlaps handoff theme #4.
+
+### P5 — float16 is unusable on older browsers, and fails at open (low–medium)
+
+zarrita maps `float16` onto `globalThis.Float16Array`, which arrived in Chrome
+135, Firefox 129 and Safari 26. On anything older the array cannot be **opened**
+— so the variable never reaches the variable list at all, unlike a missing
+codec, which lists fine and fails on plot. Worth knowing when triaging "the
+variable isn't there" reports. On a current browser float16 works end to end.
+
+### P6 — codec failures surface as "Could not fetch data" (medium)
+
+Two separate weaknesses:
+
+- An unregistered codec reaches the user as `Unknown codec: numcodecs.quantize`
+  under the heading "Could not fetch data". Accurate, but it tells a scientist
+  nothing about what to do, and "fetch" points them at the network — which is
+  where the CORS investigation in issue #7 started from a similar message.
+- When a **registered** codec throws, zarrita wraps it in a
+  `CodecPipelineError` whose message is `Failed to decode chunk via codec "X"`
+  and whose real reason lives on `.cause`. `getErrorMessage` in
+  `src/utils/errorHandling.ts` never reads `.cause`, so the actual reason
+  (checksum mismatch, truncated chunk, bad config) is dropped before it reaches
+  the toast.
+
+This is the same shape as the fix that shipped in PR #8, and the same
+fork-friendly move: improve the message, add no data paths.
+
+### P7 — `@eeholmes/zarrita-pcodec` is a `github:` dependency (low)
+
+`package.json` pins `"github:eeholmes/zarrita-pcodec"` — no version, no
+registry, and it builds from source on install (`prepare` runs `tsc` plus a
+wasm copy). Upstream inherited this too. Publishing it to npm would make both
+repos' installs reproducible. Not a gridlook code change at all.
+
+### Not a problem, but worth recording
+
+- **Sharding works**, in both backends. `sharding_indexed` needs a store with
+  `getRange`; `zarr.FetchStore` and `icechunk-js`'s `IcechunkStore` both have
+  one, and `ZarrDataManager` wraps them in `withRangeCoalescing`, which requires
+  it as well. Confirmed against a shard written by zarr-python 3.3.0.
+- **Big-endian dtypes, `fletcher32`, `blosc`, `zstd`, `lz4`, `gzip`, `zlib`,
+  `shuffle`, `delta`, `bitround` and `pcodec` all decode correctly** against
+  reference-encoder bytes.
+- **An unregistered codec never fails at open time.** The dataset indexes, lists
+  its variables, and dies on the first chunk read — indistinguishable at a
+  glance from the CORS-blocked virtual chunks in `docs/icechunk-virtual-chunks.md`.
+  Triage should check the codec list before the network.
+
+---
+
+## 4. Options, if we decide to act
+
+Not implemented. Roughly ascending in cost, with merge surface against upstream:
+
+1. **Better error text for codec failures** (P6). A new file in `src/lib/data/`
+   that turns an `UnknownCodecError` into a message naming the codec and saying
+   the dataset needs re-encoding or a codec extension, plus unwrapping
+   `CodecPipelineError.cause`. Merge surface: a few lines at the catch site.
+   This is exactly the PR #8 pattern.
+2. **Register the trivial v3 aliases** (P1, top three rows). `quantize`,
+   `astype` and `fixedscaleoffset` as small pure-JS codecs in new files, with
+   `codecs.ts` gaining one `registry.set` line each. Plain JS, no WASM, and
+   directly upstreamable — it is the same shape as the existing `fletcher32.ts`.
+3. **Handle int64 and string variables explicitly** (P2, P3). Either convert
+   BigInt properly and reject strings with a clear message, or reject both
+   clearly. Touches `castDataVarToFloat32`, which upstream owns — a few lines.
+4. **Checksum codecs** (`crc32`, `adler32`) — small, but no known ESM dataset
+   here needs them yet. Probably not worth the diff until one shows up.
+5. **File the zarrita issue for object-form `data_type`** (P4). No gridlook
+   change; the fix belongs upstream of us.
+6. **Publish `zarrita-pcodec` to npm** (P7). Outside this repo.
+
+The one thing that clearly should **not** happen is pulling `bz2`, `lzma` or
+`zfpy` into gridlook as WebAssembly. If any of those ever matters, the pcodec
+precedent applies: a separate optional package, lazily loaded.
+
+---
+
+## 5. Manual checklist for real datasets
+
+Deliberately not in CI. Run by hand when touching this area:
+
+| Dataset                                                                     | Exercises                      |
+| --------------------------------------------------------------------------- | ------------------------------ |
+| Earthmover ERA5 Icechunk (`earthmover-icechunk-era5`, `single/spatial/blh`) | pcodec, Icechunk               |
+| `eerie.cloud.dkrz.de` CORDEX-CMIP6 ICON-CLM (`clt`)                         | fletcher32, CMIP7-era encoding |
+| Any gribscan-derived store                                                  | `gribscan.rawgrib`             |
+
+If one of these fails, check the codec list in the array metadata **before**
+suspecting the network — §3's last bullet explains why the two look alike.
+
+---
+
+## 6. Note on the one file this branch touches that upstream owns
+
+`eslint.config.js`, one line: `"tests/**"` added to `boundaries/ignore`, so the
+shared fixture helper under `tests/helpers/` does not trip
+`boundaries/no-unknown-files`. The existing ignore list already covers
+`**/*.test.ts`; this extends it to non-test files in the same tree. Everything
+else on this branch is new files.

--- a/claude/codec-support.md
+++ b/claude/codec-support.md
@@ -337,6 +337,47 @@ That removes the `tests/helpers/` directory and the `boundaries/ignore` line
 from the PR, leaving it as one new source file, one new test file, and 13 lines
 across two files upstream owns.
 
+### The two branches, and why merging back is safe
+
+They are **not** the same branch, and they must not be:
+
+- `feat/codec-support-research` — branched from this fork's `main`, which sits
+  14 commits ahead of upstream. It carries the fix, the survey tests, the
+  fixture helper, the `eslint.config.js` line and this document. This is what
+  merges into the fork's `main`.
+- `fix/codec-error-messages` — branched from **`upstream/main`**, carrying only
+  four files: `codecErrors.ts`, its test, and the two edited files. Basing it
+  on the fork's `main` instead would have dragged all 14 fork-only commits into
+  the pull request.
+
+The thing that makes a later `git merge upstream/main` safe is not the branch
+structure but the **file contents**: all four files are byte-identical between
+the two branches (same git blob hashes). When upstream merges the PR, upstream
+and the fork end up holding the same bytes, so git's three-way merge sees the
+same change on both sides and takes it once.
+
+This was verified rather than assumed, by simulating both outcomes on scratch
+branches: upstream merge-commits the PR, and upstream squash-merges it (which
+severs the shared ancestry). Both merge cleanly into a fork `main` that already
+has the task branch, and in both cases the merge changes nothing in the working
+tree — the fork already had that content. The fork-only files survive untouched.
+
+Two things would break that guarantee, and both are worth watching for:
+
+- **Editing one copy and not the other.** If a change is made to
+  `codecErrors.ts` or its test on one branch, make the identical change on the
+  other, or the next upstream merge conflicts.
+- **Maintainers revising the code during review.** If they rename something or
+  reword a message, upstream's copy diverges and the merge will conflict on
+  exactly those files. That is normal and the resolution is simply to take
+  upstream's version — but the fork's copy should then be reset to match rather
+  than merged by hand, so the two stay identical for next time.
+
+The `eslint.config.js` line and `tests/helpers/` stay fork-only. They are not
+in the PR, so upstream never touches them; the only way they conflict is if
+upstream independently edits `boundaries/ignore`, which would be a one-line
+resolution.
+
 One thing that needs no attention: upstream's `useGridDataLoader.test.ts`
 asserts `logError` was called with `"Could not fetch data"`. Because the
 explanation is applied inside `useLog` rather than at the call sites, that

--- a/claude/handoff.md
+++ b/claude/handoff.md
@@ -1,75 +1,133 @@
-# Handoff — 2026-08-27 (session 4)
+# Handoff — 2026-08-27 (session 5)
 
 Read this at the start of a new session. Cross-referenced by `CLAUDE.md`.
 
 ## Status
 
-- **Branch `main`** is at `fae9360`, in sync with `origin/main`. Working tree clean.
-- **Issues:** #1, #2, #4 and #7 are closed. **PRs:** #3, #6 and #8 merged.
-- **Remote branches:** `main` only.
+- **Branch `main`** carries the codec work (PR #9). Working tree clean.
+- **Issues:** #1, #2, #4, #5 and #7 are closed. **PRs:** #3, #6, #8 and #9 merged.
+- **Local branch `fix/codec-error-messages`** is the proposed upstream PR and is
+  **not** merged into `main` — see "The upstream PR" below. Do not delete it.
 
-## What just shipped (PR #8, issue #7)
+## What just shipped (PR #9, issue #5)
 
-A readable error when an Icechunk repository's **virtual chunks** are blocked by CORS.
+A survey of Zarr codec and data-type support, the tests to keep it honest, and
+a readable error when a codec is the reason a dataset will not plot.
 
-- **The reported symptom:** `https://data.source.coop/fish-pace/coastwatch/ocean-heat/na/` failed with a bare "Could not fetch data / Failed to fetch".
-- **The actual cause:** nothing in the data path. The repository opens fine and every variable indexes. It stores only byte-range references into NetCDF files on `coastwatch.noaa.gov`, which serves those bytes happily to `curl` but sends no `Access-Control-Allow-Origin` for any origin. The coordinates were written as `loadable_variables`, so they are materialised on source.coop (which does send CORS headers) and load — which is why the dataset lists its variables and only fails on plot.
-- **New `src/lib/data/virtualChunkFetch.ts`** — a `FetchClient` that leaves the request completely untouched (icechunk-js still builds the `Range` header and follows redirects) and only rewrites the opaque `TypeError: Failed to fetch` into a message naming the host and the likely cause. Aborts and same-origin failures pass through unchanged.
-- **New `docs/icechunk-virtual-chunks.md`** — why a repository can index but not plot, a `curl` recipe to test a host, and the three workarounds.
-- 8 new tests in `tests/unit/lib/data/virtualChunkFetch.test.ts`.
+- **`claude/codec-support.md`** is the deliverable to read first. It records
+  where codec support actually comes from, a problem list P1–P7, which problems
+  belong to gridlook vs zarrita vs numcodecs.js, how to package the upstream PR,
+  and the branch topology.
+- **`src/lib/data/codecErrors.ts`** (new) turns three opaque failures into
+  messages naming the culprit: an unregistered codec, a codec that rejected a
+  chunk (with the reason zarrita put on `cause`), and a data type the browser
+  cannot represent. Applied in `useLog`, so no call site changed its context
+  string. **No decoder was added** — an unsupported dataset still fails, it just
+  says why.
+- **Four new test files**, 104 assertions, no network. `codecSupport`,
+  `dataTypeSupport` and `pcodecSupport` are the survey; `codecErrors` covers the
+  new module. Golden chunk bytes come from Python `numcodecs` 0.16.5 and `zarr`
+  3.3.0, so a passing decode means gridlook agrees with the reference encoder.
+- **Merge surface on upstream-owned files: 14 lines.** `useLog.ts` +11,
+  `gridData.worker.ts` +2, `eslint.config.js` +1.
 
-**Merge surface on upstream-owned files: 7 lines.** `src/lib/data/icechunkStore.ts` +5/−1 (pass the fetch client to `IcechunkStore.open`) and `docs/README.md` +2. Everything else is new files.
+### The three findings worth remembering
 
-**This is diagnosis, not a workaround.** The dataset still needs a CORS-unblocking browser extension to render; gridlook does not proxy. Verified out of band that NOAA serves the exact chunk range (`206`, correct `Content-Range`) to a fully browser-shaped cross-site request and still sends no `Access-Control-Allow-Origin`, so the missing header really is the only blocker. The custom-header hypothesis in issue #7 (icechunk PR #2255) cannot help — `User-Agent` is a forbidden header in browsers.
+- **`src/lib/data/codecs.ts` is byte-identical to upstream's.** Upstream already
+  carries the `zarrita-pcodec` package. Codec support is not a fork divergence,
+  so anything done here is a candidate for upstream directly.
+- **The biggest real gap is zarr v3.** zarr-python 3 writes codec names like
+  `numcodecs.fixedscaleoffset` into `zarr.json`, and zarrita aliases only ten
+  `numcodecs.*` names. The sharp edge: the same fixedscaleoffset filter decodes
+  under v2 and fails under v3.
+- **Most of that gap is plain JavaScript, not WebAssembly.** `quantize` and
+  `astype` decode to a dtype cast; only `bz2`, `lzma` and `zfpy` need a real
+  decompressor, and none is common in ESM output. Upstream's no-WASM position
+  costs almost nothing here.
 
-## Two lessons from this session worth carrying forward
+## The upstream PR
 
-- **The "Allow CORS" extension toggle reads backwards.** A switch showing `ON` means _CORS blocking is on_; it must be clicked to `OFF` to permit cross-origin reads. Eli lost real time to this while the extension reported "ON". This is now written into `CLAUDE.md` under "Data access" — **raise it first** whenever an extension is reportedly installed and enabled yet data still will not load, together with a hard reload (a cached `206` without CORS headers replays from cache without the extension ever running). Only after both come back clean is it worth looking inside gridlook.
-- **Do not ship code for an unconfirmed hypothesis.** Mid-session I added a main-thread retry to `src/lib/grids/gridDataWorkerClient.ts` (+46) on the theory that the extension might not cover Web Worker requests. The real causes were the unhelpful message plus the toggle, so that commit was dropped before the PR. Diagnose, confirm with Eli, _then_ write the fix — extra code paths no confirmed problem requires are cost, not insurance, and they enlarge the upstream merge surface for nothing.
+`fix/codec-error-messages` is branched from **`upstream/main`**, not from this
+fork's `main` (which is 14+ commits ahead), and contains only four files:
+`codecErrors.ts`, its test, `useLog.ts` and `gridData.worker.ts`. All four CI
+steps from upstream's `lint.yml` pass on it.
 
-## Environment changes made this session
+**The four files are byte-identical on both branches, and must stay that way.**
+That is what makes a later `git merge upstream/main` clean — verified by
+simulating both a merge-commit and a squash-merge of the PR upstream and
+merging the result back; both are clean and change nothing in the tree. If a
+maintainer revises the code during review, reset the fork's copy to match
+upstream's rather than hand-merging.
 
-- **Node was already installed; the shell was the problem.** `~/.local/opt/node-v24.20.0-linux-x64` and the `~/.local/bin` symlinks survive across hubs because the home directory is persistent. What was missing was `~/.bash_profile` — a bash **login** shell (which is what the JupyterHub terminal spawns) reads `~/.bash_profile`/`~/.profile`, never `~/.bashrc`, so the `PATH` line in `~/.bashrc` never applied and `npm` looked uninstalled. Created `~/.bash_profile` sourcing `~/.bashrc`; verified in a fresh login shell. **If `npm` appears missing on a new hub, check this before reinstalling anything.**
-- Tool shells still start without `~/.local/bin` on `PATH`; prepend `export PATH="$HOME/.local/opt/node-v24.20.0-linux-x64/bin:$PATH"` in Bash calls. With that set, the Husky hooks run normally — earlier sessions had to bypass them with `-c core.hooksPath=/dev/null`, which is no longer necessary.
+The fork-only pieces — `tests/helpers/zarrStoreFixtures.ts`, the survey tests,
+the `eslint.config.js` line and `claude/codec-support.md` — are deliberately not
+in that PR.
+
+Status: branch prepared locally, **not yet pushed**. Eli opens the PR himself
+with a note for the maintainers.
 
 ## Immediate next candidates
 
-From `claude/comparison.md`, the remaining **High** priority themes:
+Eli's stated order of business is diagnosis before fixes, so the survey's
+follow-ons are now the shortlist. From `claude/codec-support.md` §5:
 
-| #   | Theme                                          | comparison.md section | Rough scope                                                                                                                                                     |
-| --- | ---------------------------------------------- | --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 2   | Nested-group / root-group handling             | §2                    | Deep-group Icechunk URLs, downsampled sibling groups; touches `ZarrDataManager` and `sourceIndexing`                                                            |
-| 3   | Extra Zarr codecs (fletcher32, blosc2, pcodec) | §3                    | Upstream has `codecs.ts` and `fletcher32.ts` — check codec set, add missing decoders                                                                            |
-| 4   | Zarr v3 metadata edge cases                    | §4                    | `_ARRAY_DIMENSIONS` fallback, object-style `data_type`, unconsolidated metadata                                                                                 |
-| 10  | Load-time & interaction performance            | §10                   | **Subtle** — upstream has since moved to worker-based grid pipeline (`src/lib/grids/*.worker.ts`); some fork perf tricks may now be obsolete or need re-shaping |
+| Next                                               | Home         | Rough scope                                                                              |
+| -------------------------------------------------- | ------------ | ---------------------------------------------------------------------------------------- |
+| Explain int64 and string variables (P2, P3)        | gridlook     | Same shape as what just shipped; `toNumber` in `timeHandling.ts` already solves the cast |
+| Register `quantize` and `astype` (P1, trivial row) | gridlook     | New files shaped like `fletcher32.ts`, one `registry.set` line each                      |
+| Object-form `data_type` crashes (P4)               | zarrita      | File an issue at `manzt/zarrita.js`; crashes even on `{"name": "float32"}`               |
+| v2/v3 `fixedscaleoffset` asymmetry (P1)            | zarrita      | File an issue; report the asymmetry, not a feature request                               |
+| `bz2` / `lzma` / `zfpy` (P1, last row)             | numcodecs.js | File the gap Eli already named in d70-t/gridlook#180                                     |
 
-Theme #1 (Icechunk-js store backend) is effectively **resolved** — upstream's `src/lib/data/icechunkStore.ts` works, and PR #8 confirmed it opens format-v2 repositories and indexes them correctly. Re-read §1 before assuming anything is still outstanding there.
-
-Ask Eli which one first. Do **not** propose porting all of them — Eli chooses per-theme.
-
-Also open: further data transforms beyond `log10` (issue #4 noted more would follow). The registry in `src/lib/data/valueTransform.ts` is ready for them.
+Still open from earlier sessions, in `claude/comparison.md`: theme #2
+(nested-group handling), #4 (Zarr v3 metadata edge cases — overlaps P4), #10
+(load-time performance). Ask Eli which; do not propose porting all of them.
 
 ## Working principles
 
-- Fork-only changes must minimize edits to upstream files. Prefer new files + tiny delegation shims, and prefer GitHub-side settings over editing inherited config.
-- This repo is a fork of `d70-t/gridlook`. Fork-only work does not target upstream.
-- Local dev is behind JupyterHub — dev URL uses `/proxy/absolute/3000/` (not `/proxy/3000/`). `npm run dev` handles this automatically via `vite.jupyter.config.ts`.
-- Verify with `npm run lint-ci && npm run typecheck && npm run test && npm run build` before every commit.
-- Follow Conventional Commits (Commitlint enforces them). No changelog is generated — Release Please is off and stays off.
-- Delegate broad research (multi-PR reads, cross-file audits) to Explore or general-purpose agents so the main context stays lean.
+- **Diagnosis ships before the fix.** When a failure is opaque, build the
+  message that names the specific culprit first and let Eli decide separately
+  whether the fix is worth the merge surface. An unsupported codec is invisible
+  until someone opens a dataset that uses it, and a generic "could not load"
+  destroys the evidence needed to report it upstream.
+- Fork-only changes must minimize edits to upstream files. Prefer new files +
+  tiny delegation shims, and prefer GitHub-side settings over editing inherited
+  config.
+- **Anything proposed upstream needs tests.** Upstream's `lint.yml` runs
+  `npm run test` on every push and PR, upstream carries 20 test files including
+  ones over the composable and toast layer, and every substantive PR among the
+  last twelve merged changed `tests/`.
+- Verify with `npm run lint-ci && npm run typecheck && npm run test && npm run build`
+  before every commit.
+- Follow Conventional Commits (Commitlint enforces them). No changelog is
+  generated — Release Please is off and stays off.
+- Delegate broad research (multi-PR reads, cross-file audits) to Explore or
+  general-purpose agents so the main context stays lean.
 
-## Environment quirks worth remembering
+## Environment notes
 
-- `strictPort: true` is set for dev — port 3000 conflicts fail loudly. Kill stray processes with `pkill -9 -f "vite --port"`.
-- Do not launch background dev servers from tool calls. Vite processes started that way persist across turns and block subsequent runs.
-- HMR through the proxy may or may not connect cleanly. Manual refresh works either way.
-- Remote branch deletion and repo-settings writes via `gh api` are blocked by the permission classifier — hand those commands to Eli instead of retrying. (`gh pr merge --delete-branch` does work.)
+- **Node is already installed**; if `npm` looks missing, suspect the shell.
+  `~/.local/opt/node-v24.20.0-linux-x64` persists across hubs. Tool shells may
+  start without it on `PATH` — prepend
+  `export PATH="$HOME/.local/opt/node-v24.20.0-linux-x64/bin:$PATH"`.
+- **Python has `numcodecs` 0.16.5, `numpy` and `zarr` 3.3.0.** That is how the
+  golden chunk bytes and the zarr v3 metadata fixtures in the codec tests were
+  generated; use it again rather than hand-rolling bytes.
+- An `upstream` remote (`d70-t/gridlook`) is configured. `main` is 14+ commits
+  ahead of it and 0 behind.
+- `strictPort: true` for dev — kill strays with `pkill -9 -f "vite --port"`.
+- Do not launch background dev servers from tool calls; they persist across
+  turns and block later runs.
+- Remote branch deletion and repo-settings writes via `gh api` are blocked by
+  the permission classifier — hand those to Eli. (`gh pr merge --delete-branch`
+  does work.)
 
 ## How to resume
 
 Start a new session and say either:
 
-- **"read `claude/handoff.md` and tell me what's next"** — gets you a status summary + shortlist
-- **"port theme #N from the comparison"** — where N is one of the High-priority items above (or any of the 12 themes in `claude/comparison.md`)
-- **"add a <name> transform"** — extends `src/lib/data/valueTransform.ts`
-- **"look at something else in gridlook-xl"** — free-form investigation
+- **"read `claude/handoff.md` and tell me what's next"**
+- **"do P2 and P3"** — explain int64 and string variables, per `codec-support.md`
+- **"file the zarrita issue"** — P4, the object-form `data_type` crash
+- **"port theme #N from the comparison"**
+- **"look at something else in gridlook-xl"**

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -165,6 +165,7 @@ export default [
       "boundaries/ignore": [
         "**/*.spec.ts",
         "**/*.test.ts",
+        "tests/**",
         "env.d.ts",
         "vite.config.ts",
         "scripts/**",

--- a/src/lib/data/codecErrors.ts
+++ b/src/lib/data/codecErrors.ts
@@ -1,0 +1,143 @@
+import * as zarr from "zarrita";
+
+/**
+ * A dataset whose chunks use a codec gridlook has no decoder for behaves
+ * exactly like a dataset that is merely slow or unreachable: the repository
+ * opens, every variable is listed, and the failure only arrives on the first
+ * chunk read. zarrita raises a precise error at that point — it names the
+ * codec — but the message reaches the reader under a "Could not fetch data"
+ * heading that points at the network, which is the wrong place to look.
+ *
+ * This module classifies those errors and rewrites them into something that
+ * says which codec is missing. It changes no behaviour and adds no data path:
+ * an unsupported dataset still fails, it just says why. Naming the codec is
+ * also what makes the gap reportable — an unsupported codec is invisible until
+ * someone runs into a dataset that uses it.
+ *
+ * Errors are matched both structurally and by message text, because the grid
+ * data worker flattens errors to a plain string before posting them back to
+ * the main thread (see `src/lib/grids/gridData.worker.ts`), so by the time one
+ * reaches the UI its class and fields are gone.
+ */
+
+export type TDataErrorExplanation = {
+  heading: string;
+  detail: string;
+};
+
+const UNKNOWN_CODEC = /^Unknown codec:\s*(\S+)/;
+const CODEC_PIPELINE = /^Failed to (?:de|en)code chunk via codec "([^"]+)"/;
+const UNSUPPORTED_DATA_TYPE = /^Unknown or unsupported dataType:\s*(\S+)/;
+
+/** The `: reason` the worker appends when flattening a wrapped error. */
+const FLATTENED_CAUSE = /(?:^|\s)—\s(.+)$/;
+
+function messageOf(error: unknown) {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return typeof error === "string" ? error : "";
+}
+
+function causeMessageOf(error: unknown) {
+  if (error instanceof Error && error.cause instanceof Error) {
+    return error.cause.message;
+  }
+  // Across the worker boundary the cause survives only as flattened text.
+  return messageOf(error).match(FLATTENED_CAUSE)?.[1];
+}
+
+function unknownCodecName(error: unknown) {
+  if (zarr.isZarritaError(error, "UnknownCodecError")) {
+    return error.codec;
+  }
+  return messageOf(error).match(UNKNOWN_CODEC)?.[1];
+}
+
+function failingCodecName(error: unknown) {
+  if (zarr.isZarritaError(error, "CodecPipelineError")) {
+    return error.codec;
+  }
+  return messageOf(error).match(CODEC_PIPELINE)?.[1];
+}
+
+function unsupportedDataType(error: unknown) {
+  return messageOf(error).match(UNSUPPORTED_DATA_TYPE)?.[1];
+}
+
+function explainUnknownCodec(codec: string): TDataErrorExplanation {
+  return {
+    heading: `Unsupported codec: ${codec}`,
+    detail:
+      `This dataset's chunks are compressed with "${codec}", which gridlook ` +
+      `has no decoder for. The data and the connection are fine — only the ` +
+      `codec is missing. Quote that codec name when reporting it.`,
+  };
+}
+
+function explainCodecFailure(
+  codec: string,
+  cause: string | undefined
+): TDataErrorExplanation {
+  return {
+    heading: `Codec failed: ${codec}`,
+    detail: cause
+      ? `Decoding a chunk with "${codec}" failed: ${cause}`
+      : `Decoding a chunk with "${codec}" failed. The codec is available but ` +
+        `rejected this dataset's chunks.`,
+  };
+}
+
+function explainUnsupportedDataType(dataType: string): TDataErrorExplanation {
+  const isFloat16 = dataType.startsWith("float16");
+  return {
+    heading: `Unsupported data type: ${dataType}`,
+    detail: isFloat16
+      ? `This variable is stored as ${dataType}, which this browser cannot ` +
+        `represent. Chrome 135, Firefox 129 or Safari 26 and newer support it.`
+      : `This variable is stored as ${dataType}, which gridlook cannot read.`,
+  };
+}
+
+/**
+ * Recognise a codec or data-type failure and describe it in the reader's
+ * terms. Returns `undefined` for everything else, so callers fall back to
+ * whatever they showed before.
+ */
+export function explainDataError(
+  error: unknown
+): TDataErrorExplanation | undefined {
+  const missingCodec = unknownCodecName(error);
+  if (missingCodec) {
+    return explainUnknownCodec(missingCodec);
+  }
+
+  const brokenCodec = failingCodecName(error);
+  if (brokenCodec) {
+    return explainCodecFailure(brokenCodec, causeMessageOf(error));
+  }
+
+  const dataType = unsupportedDataType(error);
+  if (dataType) {
+    return explainUnsupportedDataType(dataType);
+  }
+
+  return undefined;
+}
+
+/**
+ * Flatten an error to a string that survives `postMessage`.
+ *
+ * zarrita reports a codec that threw as a `CodecPipelineError` naming the
+ * codec, with the reason it threw — a checksum mismatch, a truncated chunk —
+ * on `cause`. Structured-cloning an Error keeps neither the subclass nor the
+ * cause, so a worker that posts back only `error.message` drops the reason
+ * before anyone can read it. Appending the cause keeps both halves.
+ */
+export function flattenErrorMessage(error: unknown): string {
+  if (!(error instanceof Error)) {
+    return String(error);
+  }
+  const cause = error.cause instanceof Error ? error.cause.message : undefined;
+  return cause ? `${error.message} — ${cause}` : error.message;
+}

--- a/src/lib/grids/gridData.worker.ts
+++ b/src/lib/grids/gridData.worker.ts
@@ -1,5 +1,6 @@
 /// <reference lib="webworker" />
 
+import { flattenErrorMessage } from "@/lib/data/codecErrors.ts";
 import { ZarrDataManager } from "@/lib/data/ZarrDataManager.ts";
 import {
   GridDataWorkerMessageType,
@@ -35,7 +36,7 @@ workerScope.onmessage = async (event: MessageEvent<TGridDataWorkerRequest>) => {
     const response: TGridDataWorkerResponse = {
       requestId,
       type: GridDataWorkerMessageType.ERROR,
-      message: error instanceof Error ? error.message : String(error),
+      message: flattenErrorMessage(error),
     };
     workerScope.postMessage(response);
   }

--- a/src/ui/common/useLog.ts
+++ b/src/ui/common/useLog.ts
@@ -1,6 +1,11 @@
 import { ToastType, useToast } from "./useToast.ts";
 
+import { explainDataError } from "@/lib/data/codecErrors.ts";
 import { getErrorMessage, toNormalizedError } from "@/utils/errorHandling.ts";
+
+// A codec or data-type failure is worth reading and worth writing down, so it
+// stays up longer than a transient error.
+const EXPLAINED_ERROR_DURATION = 12000;
 
 export function useLog() {
   const { addToast } = useToast();
@@ -8,10 +13,14 @@ export function useLog() {
   function logError(maybeError: unknown, context?: string) {
     const error = toNormalizedError(maybeError);
     console.error(context, error, error?.stack);
-    const prefix = context ?? "Error";
+    // A recognised codec problem describes itself better than the call site
+    // can: "Could not fetch data" sends the reader to the network, which is
+    // not where the problem is.
+    const explanation = explainDataError(maybeError);
+    const prefix = explanation?.heading ?? context ?? "Error";
     addToast(prefix, {
-      detail: `${getErrorMessage(error)}`,
-      duration: 4000,
+      detail: explanation?.detail ?? `${getErrorMessage(error)}`,
+      duration: explanation ? EXPLAINED_ERROR_DURATION : 4000,
       type: ToastType.DANGER,
     });
   }

--- a/tests/helpers/zarrStoreFixtures.ts
+++ b/tests/helpers/zarrStoreFixtures.ts
@@ -1,0 +1,149 @@
+/**
+ * Helpers for building in-memory Zarr stores in tests.
+ *
+ * Zarr metadata keys are snake_case, which the repository's `camelcase` ESLint
+ * rule rejects. As in `tests/unit/lib/data/logBins.test.ts`, they are written
+ * through a constant map of computed keys — collected here so no other test
+ * file has to repeat the trick.
+ */
+
+const ZARR_KEY = {
+  ATTRIBUTES: "attributes",
+  CHUNK_GRID: "chunk_grid",
+  CHUNK_KEY_ENCODING: "chunk_key_encoding",
+  CHUNK_SHAPE: "chunk_shape",
+  DATA_TYPE: "data_type",
+  FILL_VALUE: "fill_value",
+  INDEX_CODECS: "index_codecs",
+  INDEX_LOCATION: "index_location",
+  NODE_TYPE: "node_type",
+  ZARR_FORMAT: "zarr_format",
+} as const;
+
+/** Decode a base64 chunk literal into the bytes a store would serve. */
+export function base64Bytes(encoded: string) {
+  return Uint8Array.from(atob(encoded), (character) => character.charCodeAt(0));
+}
+
+export type TV2ArrayOptions = {
+  chunks?: number[];
+  compressor?: unknown;
+  dtype: string;
+  filters?: unknown[];
+  shape?: number[];
+};
+
+export function v2ArrayMetadata(options: TV2ArrayOptions) {
+  const shape = options.shape ?? [4];
+  return {
+    chunks: options.chunks ?? shape,
+    compressor: options.compressor ?? null,
+    dtype: options.dtype,
+    filters: options.filters ?? [],
+    order: "C",
+    shape,
+    [ZARR_KEY.FILL_VALUE]: null,
+    [ZARR_KEY.ZARR_FORMAT]: 2,
+  };
+}
+
+export type TV3ArrayOptions = {
+  chunkShape?: number[];
+  codecs?: unknown[];
+  dataType: unknown;
+  shape?: number[];
+};
+
+export const V3_BYTES_CODEC = {
+  configuration: { endian: "little" },
+  name: "bytes",
+};
+
+export function v3ArrayMetadata(options: TV3ArrayOptions) {
+  const shape = options.shape ?? [4];
+  return {
+    codecs: options.codecs ?? [V3_BYTES_CODEC],
+    shape,
+    [ZARR_KEY.ATTRIBUTES]: {},
+    [ZARR_KEY.CHUNK_GRID]: {
+      configuration: { [ZARR_KEY.CHUNK_SHAPE]: options.chunkShape ?? shape },
+      name: "regular",
+    },
+    [ZARR_KEY.CHUNK_KEY_ENCODING]: { name: "default" },
+    [ZARR_KEY.DATA_TYPE]: options.dataType,
+    [ZARR_KEY.FILL_VALUE]: 0,
+    [ZARR_KEY.NODE_TYPE]: "array",
+    [ZARR_KEY.ZARR_FORMAT]: 3,
+  };
+}
+
+/**
+ * A `sharding_indexed` codec entry, as zarr-python 3 writes it. Its own
+ * configuration keys are snake_case too, so it is built here rather than
+ * inline in a test.
+ */
+export function shardingCodec(chunkShape: number[]) {
+  return {
+    configuration: {
+      codecs: [V3_BYTES_CODEC],
+      [ZARR_KEY.CHUNK_SHAPE]: chunkShape,
+      [ZARR_KEY.INDEX_CODECS]: [V3_BYTES_CODEC, { name: "crc32c" }],
+      [ZARR_KEY.INDEX_LOCATION]: "end",
+    },
+    name: "sharding_indexed",
+  };
+}
+
+function encodeMetadata(metadata: unknown) {
+  return new TextEncoder().encode(JSON.stringify(metadata));
+}
+
+/** A single-chunk zarr v2 array store, keyed the way zarrita expects. */
+export function v2Store(metadata: unknown, chunk: Uint8Array) {
+  return new Map([
+    ["/.zarray", encodeMetadata(metadata)],
+    ["/0", chunk],
+  ]);
+}
+
+/** A single-chunk zarr v3 array store. */
+export function v3Store(metadata: unknown, chunk: Uint8Array) {
+  return new Map([
+    ["/zarr.json", encodeMetadata(metadata)],
+    ["/c/0", chunk],
+  ]);
+}
+
+/**
+ * A store that can serve byte ranges. `sharding_indexed` reads the shard index
+ * before the inner chunk, so zarrita refuses to decode a shard from a store
+ * without `getRange`. Both stores gridlook uses (`zarr.FetchStore` and
+ * `icechunk-js`'s `IcechunkStore`) implement it, and `ZarrDataManager` wraps
+ * them in `zarr.withRangeCoalescing`, which requires it too.
+ */
+export class RangeReadableStore {
+  #entries: Map<string, Uint8Array>;
+
+  constructor(entries: Map<string, Uint8Array>) {
+    this.#entries = entries;
+  }
+
+  async get(key: string) {
+    return this.#entries.get(key);
+  }
+
+  async getRange(
+    key: string,
+    range: { length?: number; offset?: number; suffixLength?: number }
+  ) {
+    const value = this.#entries.get(key);
+    if (!value) {
+      return undefined;
+    }
+    if (range.suffixLength !== undefined) {
+      return value.subarray(value.length - range.suffixLength);
+    }
+    const offset = range.offset ?? 0;
+    return value.subarray(offset, offset + (range.length ?? value.length));
+  }
+}

--- a/tests/unit/lib/data/codecErrors.test.ts
+++ b/tests/unit/lib/data/codecErrors.test.ts
@@ -3,12 +3,6 @@ import { get, open } from "zarrita";
 
 import "@/lib/data/codecs.ts";
 import {
-  base64Bytes,
-  v2ArrayMetadata,
-  v2Store,
-} from "../../../helpers/zarrStoreFixtures.ts";
-
-import {
   explainDataError,
   flattenErrorMessage,
 } from "@/lib/data/codecErrors.ts";
@@ -19,17 +13,47 @@ import {
  *
  * Each case is checked twice: once as thrown, and once after the round trip
  * through `flattenErrorMessage` plus `new Error(...)` that the grid data
- * worker performs, which strips the error's class and fields.
+ * worker performs, which strips the error's class and its fields.
  */
+
+const V2MetadataKey = {
+  FILL_VALUE: "fill_value",
+  ZARR_FORMAT: "zarr_format",
+} as const;
+
+function base64Bytes(encoded: string) {
+  return Uint8Array.from(atob(encoded), (character) => character.charCodeAt(0));
+}
 
 /** What `gridData.worker.ts` posts back and `gridDataWorkerClient.ts` rebuilds. */
 function throughWorker(error: unknown) {
   return new Error(flattenErrorMessage(error));
 }
 
+function v2Store(dtype: string, compressor: unknown, chunk: Uint8Array) {
+  const metadata = new TextEncoder().encode(
+    JSON.stringify({
+      chunks: [4],
+      compressor,
+      dtype,
+      filters: [],
+      order: "C",
+      shape: [4],
+      [V2MetadataKey.FILL_VALUE]: null,
+      [V2MetadataKey.ZARR_FORMAT]: 2,
+    })
+  );
+  return new Map([
+    ["/.zarray", metadata],
+    ["/0", chunk],
+  ]);
+}
+
 async function readV2(compressor: unknown, chunk: Uint8Array) {
-  const store = v2Store(v2ArrayMetadata({ compressor, dtype: "<f4" }), chunk);
-  return await get(await open.v2(store, { kind: "array" }));
+  const array = await open.v2(v2Store("<f4", compressor, chunk), {
+    kind: "array",
+  });
+  return await get(array);
 }
 
 function caught(promise: Promise<unknown>) {
@@ -96,13 +120,12 @@ describe("a registered codec that rejects the chunk", () => {
 
 describe("a data type this browser cannot represent", () => {
   async function unsupportedDataTypeError() {
+    // zarrita maps float16 onto `globalThis.Float16Array`, which older
+    // browsers do not have.
     const original = Reflect.get(globalThis, "Float16Array");
     Reflect.deleteProperty(globalThis, "Float16Array");
     try {
-      const store = v2Store(
-        v2ArrayMetadata({ dtype: "<f2" }),
-        new Uint8Array(8)
-      );
+      const store = v2Store("<f2", null, new Uint8Array(8));
       return await caught(open.v2(store, { kind: "array" }));
     } finally {
       Reflect.set(globalThis, "Float16Array", original);
@@ -118,8 +141,7 @@ describe("a data type this browser cannot represent", () => {
 
 describe("errors that are not codec problems", () => {
   const UNRELATED = [
-    // The CORS message from PR #8 must keep its own wording.
-    new Error("Failed to fetch chunk bytes from coastwatch.noaa.gov"),
+    new Error("Failed to fetch chunk bytes from example.invalid"),
     new TypeError("Failed to fetch"),
     new Error("Cannot convert a BigInt value to a number"),
     new Error("Not found: /some/path"),

--- a/tests/unit/lib/data/codecErrors.test.ts
+++ b/tests/unit/lib/data/codecErrors.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+import { get, open } from "zarrita";
+
+import "@/lib/data/codecs.ts";
+import {
+  base64Bytes,
+  v2ArrayMetadata,
+  v2Store,
+} from "../../../helpers/zarrStoreFixtures.ts";
+
+import {
+  explainDataError,
+  flattenErrorMessage,
+} from "@/lib/data/codecErrors.ts";
+
+/**
+ * Every error fed to `explainDataError` here is one zarrita actually threw,
+ * not a hand-written stand-in, so the patterns stay tied to the real messages.
+ *
+ * Each case is checked twice: once as thrown, and once after the round trip
+ * through `flattenErrorMessage` plus `new Error(...)` that the grid data
+ * worker performs, which strips the error's class and fields.
+ */
+
+/** What `gridData.worker.ts` posts back and `gridDataWorkerClient.ts` rebuilds. */
+function throughWorker(error: unknown) {
+  return new Error(flattenErrorMessage(error));
+}
+
+async function readV2(compressor: unknown, chunk: Uint8Array) {
+  const store = v2Store(v2ArrayMetadata({ compressor, dtype: "<f4" }), chunk);
+  return await get(await open.v2(store, { kind: "array" }));
+}
+
+function caught(promise: Promise<unknown>) {
+  return promise.then(
+    () => undefined,
+    (error: unknown) => error
+  );
+}
+
+describe("an unregistered codec", () => {
+  async function unknownCodecError() {
+    return await caught(readV2({ id: "quantize" }, new Uint8Array(16)));
+  }
+
+  it("names the codec in the heading", async () => {
+    const explanation = explainDataError(await unknownCodecError());
+    expect(explanation?.heading).toBe("Unsupported codec: numcodecs.quantize");
+  });
+
+  it("says the network is not the problem", async () => {
+    const explanation = explainDataError(await unknownCodecError());
+    expect(explanation?.detail).toContain("numcodecs.quantize");
+    expect(explanation?.detail).toContain("connection are fine");
+  });
+
+  it("is still recognised after the worker flattens it", async () => {
+    const explanation = explainDataError(
+      throughWorker(await unknownCodecError())
+    );
+    expect(explanation?.heading).toBe("Unsupported codec: numcodecs.quantize");
+  });
+});
+
+describe("a registered codec that rejects the chunk", () => {
+  // A fletcher32 chunk whose trailing checksum does not match its payload.
+  const CORRUPT_FLETCHER32 = "AACAPwAAAEAAAEBAAACAQAAAAAA=";
+
+  async function codecPipelineError() {
+    return await caught(
+      readV2({ id: "fletcher32" }, base64Bytes(CORRUPT_FLETCHER32))
+    );
+  }
+
+  it("names the codec that failed", async () => {
+    const explanation = explainDataError(await codecPipelineError());
+    expect(explanation?.heading).toBe("Codec failed: numcodecs.fletcher32");
+  });
+
+  it("keeps the reason zarrita put on the cause", async () => {
+    const explanation = explainDataError(await codecPipelineError());
+    expect(explanation?.detail).toContain("checksum mismatch");
+  });
+
+  it("keeps the reason across the worker boundary", async () => {
+    // Without `flattenErrorMessage` the cause is dropped by structured clone
+    // and the reader is told only that some codec failed.
+    const explanation = explainDataError(
+      throughWorker(await codecPipelineError())
+    );
+    expect(explanation?.heading).toBe("Codec failed: numcodecs.fletcher32");
+    expect(explanation?.detail).toContain("checksum mismatch");
+  });
+});
+
+describe("a data type this browser cannot represent", () => {
+  async function unsupportedDataTypeError() {
+    const original = Reflect.get(globalThis, "Float16Array");
+    Reflect.deleteProperty(globalThis, "Float16Array");
+    try {
+      const store = v2Store(
+        v2ArrayMetadata({ dtype: "<f2" }),
+        new Uint8Array(8)
+      );
+      return await caught(open.v2(store, { kind: "array" }));
+    } finally {
+      Reflect.set(globalThis, "Float16Array", original);
+    }
+  }
+
+  it("names the data type and the browsers that support it", async () => {
+    const explanation = explainDataError(await unsupportedDataTypeError());
+    expect(explanation?.heading).toBe("Unsupported data type: float16");
+    expect(explanation?.detail).toContain("Safari 26");
+  });
+});
+
+describe("errors that are not codec problems", () => {
+  const UNRELATED = [
+    // The CORS message from PR #8 must keep its own wording.
+    new Error("Failed to fetch chunk bytes from coastwatch.noaa.gov"),
+    new TypeError("Failed to fetch"),
+    new Error("Cannot convert a BigInt value to a number"),
+    new Error("Not found: /some/path"),
+    "a bare string",
+    undefined,
+  ];
+
+  it.each(UNRELATED)("passes through %s", (error) => {
+    expect(explainDataError(error)).toBeUndefined();
+  });
+});
+
+describe("flattenErrorMessage", () => {
+  it("returns the message when there is no cause", () => {
+    expect(flattenErrorMessage(new Error("plain"))).toBe("plain");
+  });
+
+  it("appends the cause when there is one", () => {
+    const error = new Error("outer", { cause: new Error("inner") });
+    expect(flattenErrorMessage(error)).toBe("outer — inner");
+  });
+
+  it("stringifies a non-error", () => {
+    expect(flattenErrorMessage("oops")).toBe("oops");
+  });
+});

--- a/tests/unit/lib/data/codecSupport.test.ts
+++ b/tests/unit/lib/data/codecSupport.test.ts
@@ -1,0 +1,351 @@
+import { describe, expect, it } from "vitest";
+import { get, isZarritaError, open, registry } from "zarrita";
+
+import "@/lib/data/codecs.ts";
+import {
+  base64Bytes,
+  RangeReadableStore,
+  shardingCodec,
+  V3_BYTES_CODEC,
+  v2ArrayMetadata,
+  v2Store,
+  v3ArrayMetadata,
+  v3Store,
+  type TV2ArrayOptions,
+} from "../../../helpers/zarrStoreFixtures.ts";
+
+/**
+ * Characterisation tests for the codec surface gridlook actually has.
+ *
+ * These tests describe *current* behaviour, including the gaps. A test that
+ * asserts an `UnknownCodecError` is not endorsing that error — it pins the gap
+ * so that the day the codec is registered (here, or by a zarrita bump) the
+ * suite fails loudly and this file has to be updated deliberately.
+ *
+ * Golden chunk bytes were produced with Python `numcodecs` 0.16.5:
+ *
+ *   import numcodecs as nc, numpy as np, base64
+ *   data = np.array([1.0, 2.0, 3.0, 4.0], dtype="<f4")
+ *   base64.b64encode(nc.Zstd(level=1).encode(data.tobytes()))
+ *
+ * so a passing decode means gridlook agrees with the reference encoder, not
+ * merely with itself.
+ */
+
+/** The float32 payload [1, 2, 3, 4] that every golden chunk below encodes. */
+const EXPECTED_VALUES = [1, 2, 3, 4];
+
+async function decodeV2(options: TV2ArrayOptions, chunk: Uint8Array) {
+  const store = v2Store(v2ArrayMetadata(options), chunk);
+  return await get(await open.v2(store, { kind: "array" }));
+}
+
+function f4(compressor: unknown, filters: unknown[] = []): TV2ArrayOptions {
+  return { compressor, dtype: "<f4", filters };
+}
+
+// --- Codecs that decode today -------------------------------------------
+
+const WORKING_COMPRESSORS: [string, TV2ArrayOptions, string][] = [
+  ["uncompressed", f4(null), "AACAPwAAAEAAAEBAAACAQA=="],
+  [
+    "numcodecs.zlib",
+    f4({ id: "zlib", level: 1 }),
+    "eAFjYGiwZ2BgcAAiIG5wAAAQgwJA",
+  ],
+  [
+    "numcodecs.gzip",
+    f4({ id: "gzip", level: 1 }),
+    "H4sIAPmSkGoE/2NgaLBnYGBwACIgbnAAAFQUp4sQAAAA",
+  ],
+  [
+    "numcodecs.zstd",
+    f4({ id: "zstd", level: 1 }),
+    "KLUv/SAQgQAAAACAPwAAAEAAAEBAAACAQA==",
+  ],
+  [
+    "numcodecs.lz4",
+    f4({ acceleration: 1, id: "lz4" }),
+    "EAAAAPABAACAPwAAAEAAAEBAAACAQA==",
+  ],
+  [
+    "numcodecs.blosc",
+    f4({ clevel: 5, cname: "lz4", id: "blosc", shuffle: 1 }),
+    "AgEzBBAAAAAQAAAAIAAAAAAAgD8AAABAAABAQAAAgEA=",
+  ],
+  [
+    "numcodecs.fletcher32",
+    f4({ id: "fletcher32" }),
+    "AACAPwAAAEAAAEBAAACAQABB/cM=",
+  ],
+];
+
+const WORKING_FILTERS: [string, TV2ArrayOptions, string][] = [
+  [
+    "numcodecs.shuffle",
+    f4(null, [{ elementsize: 4, id: "shuffle" }]),
+    "AAAAAAAAAACAAECAP0BAQA==",
+  ],
+  [
+    "numcodecs.bitround",
+    f4(null, [{ id: "bitround", keepbits: 5 }]),
+    "AACAPwAAAEAAAEBAAACAQA==",
+  ],
+  [
+    // Translated by zarrita into the v3 `scale_offset` + `cast_value` pair.
+    "numcodecs.fixedscaleoffset",
+    f4(null, [
+      {
+        astype: "<i4",
+        dtype: "<f4",
+        id: "fixedscaleoffset",
+        offset: 0,
+        scale: 10,
+      },
+    ]),
+    "CgAAABQAAAAeAAAAKAAAAA==",
+  ],
+];
+
+describe("codecs that decode a reference numcodecs chunk", () => {
+  it.each(WORKING_COMPRESSORS)("%s", async (_name, options, chunk) => {
+    const decoded = await decodeV2(options, base64Bytes(chunk));
+    expect(Array.from(decoded.data as Float32Array)).toEqual(EXPECTED_VALUES);
+  });
+
+  it.each(WORKING_FILTERS)("%s", async (_name, options, chunk) => {
+    const decoded = await decodeV2(options, base64Bytes(chunk));
+    expect(Array.from(decoded.data as Float32Array)).toEqual(EXPECTED_VALUES);
+  });
+
+  it("numcodecs.delta", async () => {
+    const decoded = await decodeV2(
+      { dtype: "<i4", filters: [{ dtype: "<i4", id: "delta" }] },
+      base64Bytes("CgAAAAEAAAACAAAAAwAAAA==")
+    );
+    expect(Array.from(decoded.data as Int32Array)).toEqual([10, 11, 13, 16]);
+  });
+});
+
+// --- Codecs gridlook cannot decode today ---------------------------------
+
+/**
+ * Every one of these exists in Python `numcodecs` and can therefore appear in
+ * a published store. None is registered by zarrita 0.7.4 or by
+ * `src/lib/data/codecs.ts`, so a dataset using one indexes fine and then fails
+ * at the first chunk read.
+ */
+const UNSUPPORTED_COMPRESSORS: [string, unknown, string][] = [
+  ["bz2", { id: "bz2", level: 1 }, "numcodecs.bz2"],
+  ["lzma", { id: "lzma" }, "numcodecs.lzma"],
+  ["zfpy", { id: "zfpy" }, "numcodecs.zfpy"],
+  ["crc32", { id: "crc32" }, "numcodecs.crc32"],
+  ["adler32", { id: "adler32" }, "numcodecs.adler32"],
+  ["jenkins_lookup3", { id: "jenkins_lookup3" }, "numcodecs.jenkins_lookup3"],
+];
+
+/** numcodecs `astype`, whose own config keys are snake_case. */
+const ASTYPE_FILTER = {
+  id: "astype",
+  ["decode_dtype"]: "<f4",
+  ["encode_dtype"]: "<i4",
+};
+
+const UNSUPPORTED_FILTERS: [string, unknown, string][] = [
+  [
+    "quantize",
+    { digits: 2, dtype: "<f4", id: "quantize" },
+    "numcodecs.quantize",
+  ],
+  ["astype", ASTYPE_FILTER, "numcodecs.astype"],
+  ["packbits", { id: "packbits" }, "numcodecs.packbits"],
+  [
+    "categorize",
+    { dtype: "|O", id: "categorize", labels: ["a"] },
+    "numcodecs.categorize",
+  ],
+  ["vlen-bytes", { id: "vlen-bytes" }, "numcodecs.vlen-bytes"],
+  ["vlen-array", { dtype: "<i4", id: "vlen-array" }, "numcodecs.vlen-array"],
+];
+
+async function expectUnknownCodec(
+  options: TV2ArrayOptions,
+  expectedName: string
+) {
+  const error = await decodeV2(options, new Uint8Array(16)).catch(
+    (caught: unknown) => caught
+  );
+  expect(isZarritaError(error, "UnknownCodecError")).toBe(true);
+  expect((error as { codec: string }).codec).toBe(expectedName);
+}
+
+describe("codecs a published dataset can use but gridlook cannot decode", () => {
+  it.each(UNSUPPORTED_COMPRESSORS)(
+    "%s is unregistered",
+    async (_label, compressor, expectedName) => {
+      await expectUnknownCodec(f4(compressor), expectedName);
+    }
+  );
+
+  it.each(UNSUPPORTED_FILTERS)(
+    "%s is unregistered",
+    async (_label, filter, expectedName) => {
+      await expectUnknownCodec(f4(null, [filter]), expectedName);
+    }
+  );
+
+  it("fails only on the first chunk read, never at open time", async () => {
+    // Opening succeeds: shape, dtype and attributes are all readable, which is
+    // why such a dataset lists its variables and only breaks on plot. That is
+    // the same symptom shape as CORS-blocked Icechunk virtual chunks, so the
+    // two are easy to confuse when triaging a report.
+    const store = v2Store(
+      v2ArrayMetadata(f4({ id: "zfpy" })),
+      new Uint8Array(16)
+    );
+
+    const array = await open.v2(store, { kind: "array" });
+    expect(array.shape).toEqual([4]);
+  });
+});
+
+// --- The registry itself --------------------------------------------------
+
+const REGISTERED = [
+  // zarr v3 core codecs
+  "bytes",
+  "transpose",
+  "crc32c",
+  "gzip",
+  "zlib",
+  "zstd",
+  "blosc",
+  "lz4",
+  "vlen-utf8",
+  "json2",
+  "bitround",
+  "cast_value",
+  "scale_offset",
+  // numcodecs aliases zarrita ships for zarr v2 compatibility
+  "numcodecs.blosc",
+  "numcodecs.lz4",
+  "numcodecs.zstd",
+  "numcodecs.gzip",
+  "numcodecs.zlib",
+  "numcodecs.shuffle",
+  "numcodecs.delta",
+  "numcodecs.bitround",
+  "numcodecs.vlen-utf8",
+  "numcodecs.json2",
+  // added by src/lib/data/codecs.ts
+  "numcodecs.fletcher32",
+  "numcodecs.gribscan.rawgrib",
+  "numcodecs.log_bins",
+  "pcodec",
+  "numcodecs.pcodec",
+];
+
+/**
+ * Codec names that zarr-python 3 writes into **v3** metadata via its
+ * `numcodecs.zarr3` wrappers. `numcodecs.fixedscaleoffset` is the sharp one:
+ * it decodes under zarr v2 (translated during v2→v3 metadata conversion) but
+ * not under v3, where the name has to be in the registry.
+ */
+const UNREGISTERED = [
+  "numcodecs.fixedscaleoffset",
+  "numcodecs.quantize",
+  "numcodecs.astype",
+  "numcodecs.packbits",
+  "numcodecs.bz2",
+  "numcodecs.lzma",
+  "numcodecs.zfpy",
+  "numcodecs.crc32",
+  "numcodecs.crc32c",
+  "numcodecs.adler32",
+  "numcodecs.jenkins_lookup3",
+  "numcodecs.vlen-bytes",
+  "numcodecs.vlen-array",
+  "numcodecs.categorize",
+];
+
+describe("codec registry after importing src/lib/data/codecs.ts", () => {
+  it.each(REGISTERED)("resolves %s", async (name) => {
+    const factory = registry.get(name);
+    expect(factory, `${name} is not registered`).toBeDefined();
+    // Factories are either the codec class or a thunk returning a promise.
+    await expect(Promise.resolve(factory!())).resolves.toBeTruthy();
+  });
+
+  it.each(UNREGISTERED)("does not resolve %s", (name) => {
+    expect(registry.has(name)).toBe(false);
+  });
+
+  it("registers pcodec lazily so its WebAssembly stays out of the bundle", () => {
+    // `registerPCodec` only stores a `() => import(...)` thunk; the ~580 kB
+    // pcodec.wasm is fetched the first time a pcodec chunk is decoded. This is
+    // what makes the dependency acceptable to upstream (d70-t/gridlook#180).
+    expect(registry.get("numcodecs.pcodec")).toBeTypeOf("function");
+  });
+});
+
+// --- zarr v3 metadata written by zarr-python 3 ---------------------------
+
+/** Written by zarr-python 3.3.0 with `shards=(4,)` and no compressor. */
+const SHARD_CHUNK = "AACAPwAAAEAAAEBAAACAQAAAAAAAAAAAEAAAAAAAAABekwbG";
+
+function shardEntries() {
+  return v3Store(
+    v3ArrayMetadata({ codecs: [shardingCodec([4])], dataType: "float32" }),
+    base64Bytes(SHARD_CHUNK)
+  );
+}
+
+/** Written by zarr-python 3.3.0 with the `numcodecs.zarr3` codec wrappers. */
+const NUMCODECS_V3_CODECS = [
+  {
+    configuration: { astype: "<i4", dtype: "<f4", offset: 0, scale: 10 },
+    name: "numcodecs.fixedscaleoffset",
+  },
+  V3_BYTES_CODEC,
+  { configuration: { level: 1 }, name: "numcodecs.zstd" },
+];
+
+const NUMCODECS_V3_CHUNK = "KLUv/SAQgQAACgAAABQAAAAeAAAAKAAAAA==";
+
+describe("zarr v3 stores written by zarr-python 3", () => {
+  it("decodes a sharded array when the store supports getRange", async () => {
+    const store = new RangeReadableStore(shardEntries());
+    const decoded = await get(await open.v3(store as never, { kind: "array" }));
+    expect(Array.from(decoded.data as Float32Array)).toEqual(EXPECTED_VALUES);
+  });
+
+  it("refuses a sharded array when the store cannot serve ranges", async () => {
+    const error = await open
+      .v3(shardEntries(), { kind: "array" })
+      .then((array) => get(array))
+      .catch((caught: unknown) => caught);
+
+    expect(isZarritaError(error, "UnsupportedError")).toBe(true);
+    expect((error as Error).message).toContain("getRange");
+  });
+
+  it("cannot decode the numcodecs.zarr3 codec names it does not alias", async () => {
+    // The same fixedscaleoffset filter decodes fine under zarr v2, where
+    // zarrita translates it during v2→v3 metadata conversion. Under v3 the
+    // name has to be in the registry, and it is not — so whether a dataset
+    // loads depends on which zarr format it was written in.
+    const store = v3Store(
+      v3ArrayMetadata({ codecs: NUMCODECS_V3_CODECS, dataType: "float32" }),
+      base64Bytes(NUMCODECS_V3_CHUNK)
+    );
+    const error = await open
+      .v3(store, { kind: "array" })
+      .then((array) => get(array))
+      .catch((caught: unknown) => caught);
+
+    expect(isZarritaError(error, "UnknownCodecError")).toBe(true);
+    expect((error as { codec: string }).codec).toBe(
+      "numcodecs.fixedscaleoffset"
+    );
+  });
+});

--- a/tests/unit/lib/data/dataTypeSupport.test.ts
+++ b/tests/unit/lib/data/dataTypeSupport.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { get, isZarritaError, open } from "zarrita";
+
+import "@/lib/data/codecs.ts";
+import {
+  v2ArrayMetadata,
+  v2Store,
+  v3ArrayMetadata,
+  v3Store,
+} from "../../../helpers/zarrStoreFixtures.ts";
+
+import { castDataVarToFloat32 } from "@/lib/data/variableDecoding.ts";
+
+/**
+ * The other half of "codec support": once a chunk has been decompressed it
+ * still has to survive the trip into a Float32 texture. `castDataVarToFloat32`
+ * is the single funnel every grid renderer goes through, so its behaviour per
+ * data type is what decides whether a dataset plots, plots wrongly, or throws.
+ *
+ * As in `codecSupport.test.ts`, these tests pin current behaviour — including
+ * the two cases that are plainly wrong today (int64 throws, strings become
+ * silent NaN) — so a future fix has to update them on purpose.
+ */
+
+type TGlobalWithFloat16 = typeof globalThis & {
+  Float16Array?: new (values: number[]) => ArrayLike<number>;
+};
+
+const FLOAT32_BYTES = new Uint8Array(
+  new Float32Array([1, 2, 3, 4]).buffer.slice(0)
+);
+
+function typedStore(dtype: string, chunk: Uint8Array) {
+  return v2Store(v2ArrayMetadata({ dtype }), chunk);
+}
+
+describe("zarr data types zarrita hands to gridlook", () => {
+  it("decodes float32 to Float32Array", async () => {
+    const array = await open.v2(typedStore("<f4", FLOAT32_BYTES), {
+      kind: "array",
+    });
+    expect((await get(array)).data).toBeInstanceOf(Float32Array);
+  });
+
+  it("decodes big-endian float32", async () => {
+    const bigEndian = new Uint8Array(FLOAT32_BYTES).reverse();
+    const array = await open.v2(typedStore(">f4", bigEndian), {
+      kind: "array",
+    });
+    const decoded = await get(array);
+    expect(Array.from(decoded.data as Float32Array)).toEqual([4, 3, 2, 1]);
+  });
+
+  it("decodes float16 to a Float16Array", async () => {
+    const array = await open.v2(typedStore("<f2", new Uint8Array(8)), {
+      kind: "array",
+    });
+    const decoded = await get(array);
+    expect(decoded.data.constructor.name).toBe("Float16Array");
+  });
+
+  it("decodes int64 to a BigInt64Array", async () => {
+    const array = await open.v2(typedStore("<i8", new Uint8Array(32)), {
+      kind: "array",
+    });
+    expect((await get(array)).data).toBeInstanceOf(BigInt64Array);
+  });
+});
+
+describe("float16 on browsers without Float16Array", () => {
+  const globalWithFloat16 = globalThis as TGlobalWithFloat16;
+  const original = globalWithFloat16.Float16Array;
+
+  afterEach(() => {
+    globalWithFloat16.Float16Array = original;
+  });
+
+  it("fails at open time, not at read time", async () => {
+    // zarrita maps the float16 data type straight onto
+    // `globalThis.Float16Array`, which only landed in Chrome 135, Firefox 129
+    // and Safari 26. On anything older the variable cannot even be opened, so
+    // it never reaches the variable list — a different symptom from a missing
+    // codec, which lists fine and fails on plot.
+    Reflect.deleteProperty(globalThis, "Float16Array");
+    const error = await open
+      .v2(typedStore("<f2", new Uint8Array(8)), { kind: "array" })
+      .catch((caught: unknown) => caught);
+
+    expect(isZarritaError(error, "InvalidMetadataError")).toBe(true);
+    expect((error as Error).message).toContain("float16");
+  });
+});
+
+describe("zarr v3 data types written as objects", () => {
+  function objectTypedStore(dataType: unknown) {
+    return v3Store(v3ArrayMetadata({ dataType }), FLOAT32_BYTES);
+  }
+
+  it("throws a bare TypeError rather than a zarrita error", async () => {
+    // The zarr v3 spec allows `data_type` to be an object with `name` and
+    // `configuration`, which is how zarr-python writes extension types such as
+    // `numpy.datetime64`. zarrita 0.7.4 assumes a string and calls
+    // `dataType.match(...)`, so the failure is an unclassifiable TypeError
+    // that no `isZarritaError` check can catch and no message explains.
+    const dataType = { configuration: { unit: "s" }, name: "numpy.datetime64" };
+    const error = await open
+      .v3(objectTypedStore(dataType), { kind: "array" })
+      .catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(TypeError);
+    expect(isZarritaError(error)).toBe(false);
+  });
+
+  it("throws the same TypeError even for a plain wrapped core type", async () => {
+    const error = await open
+      .v3(objectTypedStore({ name: "float32" }), { kind: "array" })
+      .catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(TypeError);
+  });
+});
+
+describe("castDataVarToFloat32", () => {
+  const CONVERTIBLE: [string, ArrayLike<number>, number[]][] = [
+    ["Float32Array", new Float32Array([1.5, 2.5]), [1.5, 2.5]],
+    ["Float64Array", new Float64Array([1.5, 2.5]), [1.5, 2.5]],
+    ["Int16Array", new Int16Array([1, 2]), [1, 2]],
+    ["Int32Array", new Int32Array([1, 2]), [1, 2]],
+    ["Uint8Array", new Uint8Array([1, 2]), [1, 2]],
+  ];
+
+  it.each(CONVERTIBLE)("converts %s", (_label, input, expected) => {
+    expect(Array.from(castDataVarToFloat32(input as never))).toEqual(expected);
+  });
+
+  it("converts float16 data once Float16Array exists", () => {
+    const Float16 = (globalThis as TGlobalWithFloat16).Float16Array!;
+    const converted = castDataVarToFloat32(new Float16([1.5, 2.5]) as never);
+    expect(Array.from(converted)).toEqual([1.5, 2.5]);
+  });
+
+  const BIGINT_ARRAYS: [string, ArrayLike<bigint>][] = [
+    ["BigInt64Array", new BigInt64Array([1n, 2n])],
+    ["BigUint64Array", new BigUint64Array([1n, 2n])],
+  ];
+
+  it.each(BIGINT_ARRAYS)("throws on %s", (_label, input) => {
+    // int64/uint64 data variables are rare but legal, and `Float32Array.from`
+    // refuses BigInt outright. The user sees "Cannot convert a BigInt value to
+    // a number", which says nothing about data types or the variable involved.
+    expect(() => castDataVarToFloat32(input as never)).toThrow(TypeError);
+  });
+
+  it("silently turns string data into NaN", () => {
+    // vlen-utf8 arrays decode successfully and then become an all-NaN texture:
+    // no error, no toast, just an empty plot.
+    const converted = castDataVarToFloat32(["a", "b"] as never);
+    expect(Array.from(converted)).toEqual([NaN, NaN]);
+  });
+});

--- a/tests/unit/lib/data/pcodecSupport.test.ts
+++ b/tests/unit/lib/data/pcodecSupport.test.ts
@@ -1,0 +1,57 @@
+import { expect, it } from "vitest";
+import { get, open } from "zarrita";
+
+import "@/lib/data/codecs.ts";
+import {
+  base64Bytes,
+  V3_BYTES_CODEC,
+  v2ArrayMetadata,
+  v2Store,
+  v3ArrayMetadata,
+  v3Store,
+} from "../../../helpers/zarrStoreFixtures.ts";
+
+/**
+ * pcodec is the codec that prompted d70-t/gridlook#180. It is a numcodecs
+ * compression codec (used by the Earthmover ERA5 Icechunk store) that
+ * `numcodecs.js` does not implement, so it reaches gridlook through the
+ * separate `@eeholmes/zarrita-pcodec` package, which lazily loads a
+ * WebAssembly build only when a pcodec chunk is actually read.
+ *
+ * The chunk below is the reference fixture from that package
+ * (`test/fixtures/pcodec-int32.bin`): 8 int32 values [3, 1, 4, 1, 5, 9, 2, 6].
+ */
+
+const PCODEC_INT32_CHUNK = "cGNvIQMAAwIEAQMHAAAAEAAIAAAAJAACA4RRAA==";
+const EXPECTED = [3, 1, 4, 1, 5, 9, 2, 6];
+const SHAPE = [8];
+
+it("decodes a pcodec-compressed zarr v2 chunk", async () => {
+  const store = v2Store(
+    v2ArrayMetadata({
+      compressor: { id: "pcodec" },
+      dtype: "<i4",
+      shape: SHAPE,
+    }),
+    base64Bytes(PCODEC_INT32_CHUNK)
+  );
+
+  const decoded = await get(await open.v2(store, { kind: "array" }));
+
+  expect(Array.from(decoded.data as Int32Array)).toEqual(EXPECTED);
+});
+
+it("decodes a pcodec-compressed zarr v3 chunk", async () => {
+  const store = v3Store(
+    v3ArrayMetadata({
+      codecs: [V3_BYTES_CODEC, { configuration: {}, name: "numcodecs.pcodec" }],
+      dataType: "int32",
+      shape: SHAPE,
+    }),
+    base64Bytes(PCODEC_INT32_CHUNK)
+  );
+
+  const decoded = await get(await open.v3(store, { kind: "array" }));
+
+  expect(Array.from(decoded.data as Int32Array)).toEqual(EXPECTED);
+});


### PR DESCRIPTION
Closes #5.

Surveys which Zarr codecs and data types gridlook can actually read, adds the tests to keep that honest, and makes a codec failure say so instead of reporting a generic load error. **No codec fixes are implemented** — that was the ask in #5, and the choice of which gaps to close is deliberately left open.

## The survey

`claude/codec-support.md` is the thing to read. It records where codec support comes from, a problem list P1–P7, which problems belong to gridlook vs zarrita vs numcodecs.js, and how to package the upstream PR.

Three findings worth pulling out:

- **`src/lib/data/codecs.ts` is byte-identical to upstream's.** Upstream already carries the `zarrita-pcodec` package, so codec support is not a fork divergence and anything done here is a candidate for upstream directly.
- **The biggest real gap is zarr v3.** zarr-python 3 writes codec names like `numcodecs.fixedscaleoffset` into `zarr.json`, and zarrita aliases only ten `numcodecs.*` names. The sharp edge: the same fixedscaleoffset filter decodes under v2 and fails under v3.
- **Most of that gap is plain JavaScript.** `quantize` and `astype` decode to a dtype cast; only `bz2`, `lzma` and `zfpy` need a real decompressor, and none is common in ESM output. The no-WASM constraint costs almost nothing here.

## The error message

A codec gridlook cannot decode **never fails at open time** — the store opens, every variable lists, and the failure arrives on the first chunk read, under a "Could not fetch data" heading that points at the network. That is indistinguishable at a glance from the CORS-blocked virtual chunks in #7.

`src/lib/data/codecErrors.ts` rewrites three cases into a message naming the culprit:

- an unregistered codec → `Unsupported codec: numcodecs.quantize`
- a codec that rejected a chunk → the codec, plus the reason zarrita put on `cause`
- a data type the browser lacks → the type, plus the browsers that have it

Applied inside `useLog`, so no call site changed its context string. Behaviour is unchanged: an unsupported dataset still fails, it just says why — precisely enough to report upstream, which matters because an unsupported codec is invisible until someone opens a dataset that uses it.

Two things the implementation has to work around: the grid data worker flattens errors to a plain string before `postMessage`, so the error class and fields are gone by the time one reaches the UI (classification matches on message text as well as structure), and that flattening also dropped the reason a codec threw, so `gridData.worker.ts` now appends the `cause`.

## Tests

Four new files, 104 assertions, no network. Golden chunk bytes come from Python `numcodecs` 0.16.5 and `zarr` 3.3.0, so a passing decode means gridlook agrees with the reference encoder rather than only with itself. Codecs that cannot be decoded are asserted as such, so the suite doubles as a support inventory that fails loudly if a `zarrita` bump changes anything.

## Merge surface

14 lines across files upstream owns: `useLog.ts` +11, `gridData.worker.ts` +2, `eslint.config.js` +1. Everything else is new files.

## Upstream

`fix/codec-error-messages` is prepared locally, branched from `upstream/main`, carrying only the four files of the error-message change. Those four files are byte-identical to the copies here, which is what keeps a later `git merge upstream/main` clean — verified by simulating both a merge-commit and a squash-merge of that PR and merging the result back.

`npm run lint-ci && npm run typecheck && npm run test && npm run build` all pass; 216 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FniDZANGZVtrQgN1eacurN