### PR TITLE
fix(ui): resolve colormap swatches against the app base URL

### DIFF
--- a/src/ui/overlays/HoverReadout.vue
+++ b/src/ui/overlays/HoverReadout.vue
@@ -43,7 +43,7 @@ function loadColormapImage(name: string): Promise<void> {
       resolve();
     };
     img.onerror = () => resolve();
-    img.src = `/static/colormaps/${name}.webp`;
+    img.src = `${import.meta.env.BASE_URL}static/colormaps/${name}.webp`;
   });
 }
 

--- a/src/ui/overlays/controls/ColormapControls.vue
+++ b/src/ui/overlays/controls/ColormapControls.vue
@@ -98,7 +98,7 @@ function handleBoundsHighUpdate(value: number) {
 // ---------------------------------------------------------------------------
 
 function swatchSrc(cm: TColorMap): string {
-  return `/static/colormaps/${cm}.webp`;
+  return `${import.meta.env.BASE_URL}static/colormaps/${cm}.webp`;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #10 (same symptom as `eeholmes/gridlook-xl#61`).

## The bug

Both swatch call sites requested the pre-generated WebP gradients from an
absolute, site-root URL:

```ts
`/static/colormaps/${cm}.webp`
```

The build sets `base: "./"`, so the app is served from a subpath — GitHub
Pages at `/gridlook/`, and the JupyterHub proxy prefix in dev. The leading
slash bypasses that base and points at the domain root, so every swatch
request 404s. Nothing surfaces the failure: `ColormapControls` renders a
broken `<img>` and `HoverReadout`'s `img.onerror` just resolves the promise.

## The fix

Prefix both with `import.meta.env.BASE_URL`, which Vite substitutes with the
configured `base` — `./` in the production build, the proxy prefix under
`vite.jupyter.config.ts`. Two one-line changes; no other absolute public-asset
paths exist in `src/`.

`gridlook-xl#70` fixed this by dropping the leading slash, which also works
for a hash-routed app. `BASE_URL` is the same size and stays correct if the
document is ever served from a nested path.

## Verification

- `npm run lint-ci`, `npm run typecheck`, `npm run test` (216 passing), `npm run build` all clean.
- The built bundle now emits `./static/colormaps/${…}.webp` for both call
  sites, and `dist/static/colormaps/` holds all 58 swatches.

Note: `upstream/main` carries the identical bug in both files, so this is
also worth proposing to `d70-t/gridlook`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FniDZANGZVtrQgN1eacurN